### PR TITLE
fix: handle input-object-type definitions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
             // This function triggered per each type
             const typeName = node.name.value;
 
-            if (typeName === 'Query') {
+            if (typeName === 'Query' || typeName === 'Mutation') {
                 return null;
             }
 

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -10,6 +10,22 @@ export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     };
 };
 
+export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
+    return {
+        updateUser: aUser(),
+        ...overrides
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides
+    };
+};
+
 export const aUser = (overrides?: Partial<User>): User => {
     return {
         id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
@@ -23,12 +39,28 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data functions with external types file import 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars */
-import { Avatar, User } from './types/graphql';
+import { Avatar, Mutation, UpdateUserInput, User } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
         id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
         url: 'aliquid',
+        ...overrides
+    };
+};
+
+export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
+    return {
+        updateUser: aUser(),
+        ...overrides
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
         ...overrides
     };
 };

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -10,13 +10,6 @@ export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     };
 };
 
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: aUser(),
-        ...overrides
-    };
-};
-
 export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
         id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
@@ -39,19 +32,12 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data functions with external types file import 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars */
-import { Avatar, Mutation, UpdateUserInput, User } from './types/graphql';
+import { Avatar, UpdateUserInput, User } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
         id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
         url: 'aliquid',
-        ...overrides
-    };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: aUser(),
         ...overrides
     };
 };

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -1,6 +1,6 @@
 import '@graphql-codegen/testing';
 
-import { buildSchema, print } from 'graphql';
+import { buildSchema } from 'graphql';
 import { plugin } from '../src';
 
 const testSchema = buildSchema(/* GraphQL */ `
@@ -17,6 +17,16 @@ const testSchema = buildSchema(/* GraphQL */ `
 
     type Query {
         user: User!
+    }
+
+    input UpdateUserInput {
+        id: ID!
+        login: String
+        avatar: Avatar
+    }
+
+    type Mutation {
+        updateUser(user: UpdateUserInput): User
     }
 `);
 
@@ -35,6 +45,6 @@ it('should generate mock data functions with external types file import', async 
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts' });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Avatar, User } from './types/graphql';");
+    expect(result).toContain("import { Avatar, Mutation, UpdateUserInput, User } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -45,6 +45,6 @@ it('should generate mock data functions with external types file import', async 
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts' });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Avatar, Mutation, UpdateUserInput, User } from './types/graphql';");
+    expect(result).toContain("import { Avatar, UpdateUserInput, User } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
This pr will add handler for `InputObjectTypeDefinition` in visitor config.