### PR TITLE
fix: add __typename property

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 Defines the file path containing all GraphQL types. This file can also be generated through graphql-codgen
 
+### addTypename (`boolean`, defaultValue: `false`)
+
+Adds `__typename` property to mock data
+
 ## Example of usage
 
 **codegen.yml**

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -61,3 +61,37 @@ export const aUser = (overrides?: Partial<User>): User => {
 };
 "
 `;
+
+exports[`should generate mock data with typename if addTypename is true 1`] = `
+"/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars */
+import { Avatar, UpdateUserInput, User } from './types/graphql';
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        __typename: 'Avatar',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        __typename: 'User',
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        login: 'libero',
+        avatar: anAvatar(),
+        ...overrides
+    };
+};
+"
+`;

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -48,3 +48,11 @@ it('should generate mock data functions with external types file import', async 
     expect(result).toContain("import { Avatar, UpdateUserInput, User } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
+
+it('should generate mock data with typename if addTypename is true', async () => {
+    const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts', addTypename: true });
+
+    expect(result).toBeDefined();
+    expect(result).toContain("import { Avatar, UpdateUserInput, User } from './types/graphql';");
+    expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
Add `__typename` property to mock data. This can be added if you set in
the config `addTypename: true`