### PR TITLE
Bugfix/Feature: pascalCase; Bugfix: recursive nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Defines the file path containing all GraphQL types. This file can also be genera
 
 Adds `__typename` property to mock data
 
+### enumValues (`string`, defaultValue: `upper-case#upperCase`)
+
+Change the case of the enums. Accept `upper-case#upperCase` or `pascal-case#pascalCase`
+
 ## Example of usage
 
 **codegen.yml**
@@ -33,6 +37,7 @@ generates:
     plugins:
       - 'graphql-codegen-typescript-mock-data':
           typesFile: '../generated-types.ts'
+          enumValues: pascal-case#pascalCase
 ```
 
 ## Example or generated code
@@ -41,18 +46,34 @@ Given the following schema:
 
 ```graphql
 type Avatar {
-  id: ID!
-  url: String!
+    id: ID!
+    url: String!
 }
 
 type User {
-  id: ID!
-  login: String!
-  avatar: Avatar
+    id: ID!
+    login: String!
+    avatar: Avatar
+    status: Status!
 }
 
 type Query {
-  user: User!
+    user: User!
+}
+
+input UpdateUserInput {
+    id: ID!
+    login: String
+    avatar: Avatar
+}
+
+enum Status {
+    ONLINE
+    OFFLINE
+}
+
+type Mutation {
+    updateUser(user: UpdateUserInput): User
 }
 ```
 
@@ -60,20 +81,27 @@ The code generated will look like:
 
 ```typescript
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-  return {
-    id: '1550ff93-cd31-49b4-bc38-ef1cb68bdc38',
-    url: 'aliquid',
-    ...overrides,
-  };
+    return {
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && 'url' in overrides ? overrides.url! : 'aliquid'},
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'qui'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
+    };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
-  return {
-    id: 'b5756f00-51a6-422a-9a7d-c13ee6a63750',
-    login: 'libero',
-    avatar: anAvatar(),
-    ...overrides,
-  };
+    return {
+        get id() { return overrides && 'id' in overrides ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'libero'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
+        get status() { return overrides && 'status' in overrides ? overrides.status! : Status.ONLINE},
+    };
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
     "dependencies": {
         "@graphql-codegen/plugin-helpers": "^1.8.1",
         "casual": "^1.6.2",
-        "pascal-case": "^3.1.1"
+        "pascal-case": "^3.1.1",
+        "upper-case": "^2.0.1"
     },
     "peerDependencies": {
-        "graphql": "^14.0.0"
+        "graphql": "^14.6.0"
     },
     "devDependencies": {
         "@auto-it/conventional-commits": "^7.12.3",
@@ -43,7 +44,7 @@
         "eslint-plugin-import": "^2.17.2",
         "eslint-plugin-jest": "^22.20.0",
         "eslint-plugin-prettier": "^3.0.1",
-        "graphql": "^14.5.8",
+        "graphql": "^14.6.0",
         "graphql-toolkit": "^0.5.19-beta.0",
         "jest": "^24.9.0",
         "prettier": "^1.18.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                 mockFn: (typeName: string) => {
                     const value = generateMockValue(typeName, fieldName, types, node.type, enumValues);
 
-                    return `        get ${fieldName}() { return overrides && '${fieldName}' in overrides ? overrides.${fieldName}! : ${value}},`;
+                    return `        ${fieldName}: overrides && '${fieldName}' in overrides ? overrides.${fieldName}! : ${value},`;
                 },
             };
         },
@@ -194,7 +194,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                                       enumValues,
                                   );
 
-                                  return `        get ${field.name.value}() { return overrides && '${field.name.value}' in overrides ? overrides.${field.name.value}! : ${value}},`;
+                                  return `        ${field.name.value}: overrides && '${field.name.value}' in overrides ? overrides.${field.name.value}! : ${value},`;
                               })
                               .join('\n')
                         : '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                 mockFn: (typeName: string) => {
                     const value = generateMockValue(typeName, fieldName, types, node.type, enumValues);
 
-                    return `        get ${fieldName}() { return overrides && overrides.${fieldName} ? overrides.${fieldName} : ${value}},`;
+                    return `        get ${fieldName}() { return overrides && '${fieldName}' in overrides ? overrides.${fieldName}! : ${value}},`;
                 },
             };
         },
@@ -194,7 +194,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                                       enumValues,
                                   );
 
-                                  return `        get ${field.name.value}() { return overrides && overrides.${field.name.value} ? overrides.${field.name.value} : ${value}},`;
+                                  return `        get ${field.name.value}() { return overrides && '${field.name.value}' in overrides ? overrides.${field.name.value}! : ${value}},`;
                               })
                               .join('\n')
                         : '';

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -4,27 +4,25 @@ exports[`should generate mock data functions 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: 'aliquid',
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && overrides.url ? overrides.url : 'aliquid'},
     };
 };
 
 export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: 'qui',
-        avatar: anAvatar(),
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && overrides.login ? overrides.login : 'qui'},
+        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        login: 'libero',
-        avatar: anAvatar(),
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && overrides.login ? overrides.login : 'libero'},
+        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+        get status() { return overrides && overrides.status ? overrides.status : Status.ONLINE},
     };
 };
 "
@@ -32,31 +30,59 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data functions with external types file import 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars */
-import { Avatar, UpdateUserInput, User } from './types/graphql';
+import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: 'aliquid',
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && overrides.url ? overrides.url : 'aliquid'},
     };
 };
 
 export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: 'qui',
-        avatar: anAvatar(),
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && overrides.login ? overrides.login : 'qui'},
+        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        login: 'libero',
-        avatar: anAvatar(),
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && overrides.login ? overrides.login : 'libero'},
+        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+        get status() { return overrides && overrides.status ? overrides.status : Status.ONLINE},
+    };
+};
+"
+`;
+
+exports[`should generate mock data with pascalCase enum if enumValues is "pascal-case#pascalCase" 1`] = `
+"/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars */
+import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        get id() { return overrides && overrides.id ? overrides.id : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && overrides.url ? overrides.url : 'aliquid'},
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        get id() { return overrides && overrides.id ? overrides.id : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && overrides.login ? overrides.login : 'qui'},
+        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        get id() { return overrides && overrides.id ? overrides.id : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && overrides.login ? overrides.login : 'libero'},
+        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+        get status() { return overrides && overrides.status ? overrides.status : Status.Online},
     };
 };
 "
@@ -64,33 +90,31 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data with typename if addTypename is true 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars */
-import { Avatar, UpdateUserInput, User } from './types/graphql';
+import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
         __typename: 'Avatar',
-        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: 'aliquid',
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && overrides.url ? overrides.url : 'aliquid'},
     };
 };
 
 export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: 'qui',
-        avatar: anAvatar(),
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && overrides.login ? overrides.login : 'qui'},
+        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
         __typename: 'User',
-        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        login: 'libero',
-        avatar: anAvatar(),
-        ...overrides
+        get id() { return overrides && overrides.id ? overrides.id : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && overrides.login ? overrides.login : 'libero'},
+        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+        get status() { return overrides && overrides.status ? overrides.status : Status.ONLINE},
     };
 };
 "

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -4,25 +4,25 @@ exports[`should generate mock data functions 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
-        get url() { return overrides && overrides.url ? overrides.url : 'aliquid'},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && 'url' in overrides ? overrides.url! : 'aliquid'},
     };
 };
 
 export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
-        get login() { return overrides && overrides.login ? overrides.login : 'qui'},
-        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'qui'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
-        get login() { return overrides && overrides.login ? overrides.login : 'libero'},
-        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
-        get status() { return overrides && overrides.status ? overrides.status : Status.ONLINE},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'libero'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
+        get status() { return overrides && 'status' in overrides ? overrides.status! : Status.ONLINE},
     };
 };
 "
@@ -34,25 +34,25 @@ import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
-        get url() { return overrides && overrides.url ? overrides.url : 'aliquid'},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && 'url' in overrides ? overrides.url! : 'aliquid'},
     };
 };
 
 export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
-        get login() { return overrides && overrides.login ? overrides.login : 'qui'},
-        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'qui'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
-        get login() { return overrides && overrides.login ? overrides.login : 'libero'},
-        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
-        get status() { return overrides && overrides.status ? overrides.status : Status.ONLINE},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'libero'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
+        get status() { return overrides && 'status' in overrides ? overrides.status! : Status.ONLINE},
     };
 };
 "
@@ -64,25 +64,25 @@ import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
-        get url() { return overrides && overrides.url ? overrides.url : 'aliquid'},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && 'url' in overrides ? overrides.url! : 'aliquid'},
     };
 };
 
 export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
-        get login() { return overrides && overrides.login ? overrides.login : 'qui'},
-        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'qui'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
-        get login() { return overrides && overrides.login ? overrides.login : 'libero'},
-        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
-        get status() { return overrides && overrides.status ? overrides.status : Status.Online},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'libero'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
+        get status() { return overrides && 'status' in overrides ? overrides.status! : Status.Online},
     };
 };
 "
@@ -95,26 +95,26 @@ import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
         __typename: 'Avatar',
-        get id() { return overrides && overrides.id ? overrides.id : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
-        get url() { return overrides && overrides.url ? overrides.url : 'aliquid'},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38'},
+        get url() { return overrides && 'url' in overrides ? overrides.url! : 'aliquid'},
     };
 };
 
 export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        get id() { return overrides && overrides.id ? overrides.id : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
-        get login() { return overrides && overrides.login ? overrides.login : 'qui'},
-        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'qui'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
         __typename: 'User',
-        get id() { return overrides && overrides.id ? overrides.id : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
-        get login() { return overrides && overrides.login ? overrides.login : 'libero'},
-        get avatar() { return overrides && overrides.avatar ? overrides.avatar : anAvatar()},
-        get status() { return overrides && overrides.status ? overrides.status : Status.ONLINE},
+        get id() { return overrides && 'id' in overrides ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750'},
+        get login() { return overrides && 'login' in overrides ? overrides.login! : 'libero'},
+        get avatar() { return overrides && 'avatar' in overrides ? overrides.avatar! : anAvatar()},
+        get status() { return overrides && 'status' in overrides ? overrides.status! : Status.ONLINE},
     };
 };
 "

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -13,6 +13,7 @@ const testSchema = buildSchema(/* GraphQL */ `
         id: ID!
         login: String!
         avatar: Avatar
+        status: Status!
     }
 
     type Query {
@@ -23,6 +24,11 @@ const testSchema = buildSchema(/* GraphQL */ `
         id: ID!
         login: String
         avatar: Avatar
+    }
+
+    enum Status {
+        ONLINE
+        OFFLINE
     }
 
     type Mutation {
@@ -45,7 +51,7 @@ it('should generate mock data functions with external types file import', async 
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts' });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Avatar, UpdateUserInput, User } from './types/graphql';");
+    expect(result).toContain("import { Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
 
@@ -53,6 +59,17 @@ it('should generate mock data with typename if addTypename is true', async () =>
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts', addTypename: true });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Avatar, UpdateUserInput, User } from './types/graphql';");
+    expect(result).toContain("import { Avatar, UpdateUserInput, User, Status } from './types/graphql';");
+    expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with pascalCase enum if enumValues is "pascal-case#pascalCase"', async () => {
+    const result = await plugin(testSchema, [], {
+        enumValues: 'pascal-case#pascalCase',
+        typesFile: './types/graphql.ts',
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toContain("import { Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2484,10 +2484,10 @@ graphql-toolkit@^0.5.19-beta.0:
     "@graphql-toolkit/schema-merging" "0.5.19-beta.0"
     "@graphql-toolkit/url-loader" "0.5.19-beta.0"
 
-graphql@^14.5.8:
-  version "14.5.8"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.8.tgz#504f3d3114cb9a0a3f359bbbcf38d9e5bf6a6b3c"
-  integrity sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==
+graphql@^14.6.0:
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
+  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
   dependencies:
     iterall "^1.2.2"
 
@@ -5486,6 +5486,13 @@ upper-case@^1.0.3, upper-case@^1.1.0, upper-case@^1.1.1, upper-case@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
   integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
+
+upper-case@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.1.tgz#6214d05e235dc817822464ccbae85822b3d8665f"
+  integrity sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==
+  dependencies:
+    tslib "^1.10.0"
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
This PR is going to fix the issue with pascalCase error, initially committed by @keesvanlierop
Also, I extended that functionality to support upper case enums as well.

The other thing that was failing for me was a recursive nesting.
Check this schema
```graphql
type User {
  id: Int!
  username: String!
  tasks: [Task!]!
}

type Task {
  id: Int!
  description: String
  author: User!
  status: TaskStatus!
}
```

so, when I create a mock of a task -> user mock will be created, but then user mock will create a task mock and this will run recursively until the stack can't hold it anymore.
Overrides won't help because they come **after** the mock is created so I switched to the getters, so they won't create a nested mock if there is an override.