### PR TITLE
Issue #16: default typename casing to pascalCase and add configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Adds `__typename` property to mock data
 
 ### enumValues (`string`, defaultValue: `pascal-case#pascalCase`)
 
-Change sthe case of the enums. Accepts `upper-case#upperCase`, `pascal-case#pascalCase` or `keep`
+Changes the case of the enums. Accepts `upper-case#upperCase`, `pascal-case#pascalCase` or `keep`
 
 ### typenames (`string`, defaultValue: `pascal-case#pascalCase`)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Adds `__typename` property to mock data
 
 ### enumValues (`string`, defaultValue: `pascal-case#pascalCase`)
 
-Change the case of the enums. Accept `upper-case#upperCase` or `pascal-case#pascalCase`
+Change sthe case of the enums. Accepts `upper-case#upperCase`, `pascal-case#pascalCase` or `keep`
+
+### typenames (`string`, defaultValue: `pascal-case#pascalCase`)
+
+Changes the case of the enums. Accepts `upper-case#upperCase`, `pascal-case#pascalCase` or `keep`
 
 ## Example of usage
 
@@ -38,6 +42,7 @@ generates:
       - 'graphql-codegen-typescript-mock-data':
           typesFile: '../generated-types.ts'
           enumValues: upper-case#upperCase
+          typenames: keep
 ```
 
 ## Example or generated code

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "lint-staged": "^10.1.1",
         "prettier": "^2.0.2",
         "prettier-config-landr": "^0.0.7",
-        "ts-jest": "^25.3.1",
+        "ts-jest": "^25.4.0",
         "typescript": "^3.8.3"
     },
     "sideEffects": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,18 @@ import { PluginFunction } from '@graphql-codegen/plugin-helpers';
 import { pascalCase } from 'pascal-case';
 import { upperCase } from 'upper-case';
 
-type NamingConvention = 'upper-case#upperCase' | 'pascal-case#pascalCase';
+type NamingConvention = 'upper-case#upperCase' | 'pascal-case#pascalCase' | 'keep';
 
 const createNameConverter = (convention: NamingConvention) => (value: string) => {
     switch (convention) {
         case 'upper-case#upperCase':
             return upperCase(value || '');
         case 'pascal-case#pascalCase':
+            return pascalCase(value || '');
+        case 'keep':
+            return value;
+        default:
+            // default to pascal case in case of unknown values
             return pascalCase(value || '');
     }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,10 @@ const createNameConverter = (convention: NamingConvention) => (value: string) =>
     switch (convention) {
         case 'upper-case#upperCase':
             return upperCase(value || '');
-        case 'pascal-case#pascalCase':
-            return pascalCase(value || '');
         case 'keep':
             return value;
+        case 'pascal-case#pascalCase':
+        // fallthrough
         default:
             // default to pascal case in case of unknown values
             return pascalCase(value || '');

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,9 +120,8 @@ const generateMockValue = (
     }
 };
 
-const getMockString = (typeName: string, fields: string, addTypename = false) => {
-    const typeNamingConvention: NamingConvention = 'pascal-case#pascalCase';
-    const casedName = createNameConverter(typeNamingConvention)(typeName);
+const getMockString = (typeName: string, fields: string, typenameValues: NamingConvention, addTypename = false) => {
+    const casedName = createNameConverter(typenameValues)(typeName);
     const typename = addTypename ? `\n        __typename: '${casedName}',` : '';
     return `
 export const ${toMockName(casedName)} = (overrides?: Partial<${casedName}>): ${casedName} => {
@@ -135,6 +134,7 @@ ${fields}
 export interface TypescriptMocksPluginConfig {
     typesFile?: string;
     enumValues?: NamingConvention;
+    typenameValues?: NamingConvention;
     addTypename?: boolean;
 }
 
@@ -155,6 +155,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
     const astNode = parse(printedSchema); // Transforms the string into ASTNode
 
     const enumValues = config.enumValues || 'pascal-case#pascalCase';
+    const typenameValues = config.typenameValues || 'pascal-case#pascalCase';
     // List of types that are enums
     const types: TypeItem[] = [];
     const visitor: VisitorType = {
@@ -212,7 +213,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                               .join('\n')
                         : '';
 
-                    return getMockString(fieldName, mockFields, false);
+                    return getMockString(fieldName, mockFields, typenameValues, false);
                 },
             };
         },
@@ -230,7 +231,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                 mockFn: () => {
                     const mockFields = fields ? fields.map(({ mockFn }: any) => mockFn(typeName)).join('\n') : '';
 
-                    return getMockString(typeName, mockFields, !!config.addTypename);
+                    return getMockString(typeName, mockFields, typenameValues, !!config.addTypename);
                 },
             };
         },

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -36,7 +36,13 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data functions with external types file import 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
+import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
+
+export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -66,7 +72,13 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data with pascalCase enum if enumValues is "pascal-case#pascalCase" 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
+import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
+
+export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -96,7 +108,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data with typename if addTypename is true 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
+import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
+
+export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+    return {
+        __typename: 'ABCType',
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -128,7 +147,13 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data with upperCase enum if enumValues is "upper-case#upperCase" 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { Avatar, UpdateUserInput, User, Status } from './types/graphql';
+import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
+
+export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -2,6 +2,12 @@
 
 exports[`should generate mock data functions 1`] = `
 "
+export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`should generate mock data functions 1`] = `
 "
-export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
     };
@@ -38,7 +38,7 @@ exports[`should generate mock data functions with external types file import 1`]
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
 import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
 
-export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
     };
@@ -74,7 +74,7 @@ exports[`should generate mock data with pascalCase enum if enumValues is "pascal
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
 import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
 
-export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
     };
@@ -110,9 +110,9 @@ exports[`should generate mock data with typename if addTypename is true 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
 import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
 
-export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        __typename: 'ABCType',
+        __typename: 'AbcType',
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
     };
 };
@@ -149,7 +149,7 @@ exports[`should generate mock data with upperCase enum if enumValues is "upper-c
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
 import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
 
-export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
     };

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -29,7 +29,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
     };
 };
 "
@@ -66,13 +66,13 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
     };
 };
 "
 `;
 
-exports[`should generate mock data with as-is enum if enumValues is "keep" 1`] = `
+exports[`should generate mock data with as-is enum values if enumValues is "keep" 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
@@ -101,13 +101,13 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.hasABCStatus,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.hasXYZStatus,
     };
 };
 "
 `;
 
-exports[`should generate mock data with as-is types if typenames is "keep" 1`] = `
+exports[`should generate mock data with as-is types and enums if typenames is "keep" 1`] = `
 "
 export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
     return {
@@ -136,13 +136,13 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : ABCStatus.HasAbcStatus,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCStatus.HasXyzStatus,
     };
 };
 "
 `;
 
-exports[`should generate mock data with pascalCase enum if enumValues is "pascal-case#pascalCase" 1`] = `
+exports[`should generate mock data with pascalCase enum values by default 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
@@ -171,13 +171,13 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
     };
 };
 "
 `;
 
-exports[`should generate mock data with pascalCase types by default 1`] = `
+exports[`should generate mock data with pascalCase enum values if enumValues is "pascal-case#pascalCase" 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
@@ -206,16 +206,84 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+    };
+};
+"
+`;
+
+exports[`should generate mock data with pascalCase enum values if typenames is "pascal-case#pascalCase" 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+    };
+};
+"
+`;
+
+exports[`should generate mock data with pascalCase types and enums by default 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
     };
 };
 "
 `;
 
 exports[`should generate mock data with typename if addTypename is true 1`] = `
-"/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { ABCType, Avatar, UpdateUserInput, User, ABCStatus, Status } from './types/graphql';
-
+"
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
         __typename: 'AbcType',
@@ -246,13 +314,13 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
     };
 };
 "
 `;
 
-exports[`should generate mock data with upperCase enum if enumValues is "upper-case#upperCase" 1`] = `
+exports[`should generate mock data with upperCase enum values if enumValues is "upper-case#upperCase" 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
@@ -281,13 +349,13 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HASABCSTATUS,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HASXYZSTATUS,
     };
 };
 "
 `;
 
-exports[`should generate mock data with upperCase types if typenames is "upper-case#upperCase" 1`] = `
+exports[`should generate mock data with upperCase types and enums if typenames is "upper-case#upperCase" 1`] = `
 "
 export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
     return {
@@ -316,7 +384,7 @@ export const aUSER = (overrides?: Partial<USER>): USER => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
-        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : ABCSTATUS.HasAbcStatus,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
     };
 };
 "

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -29,6 +29,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
     };
 };
 "
@@ -36,7 +37,7 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data functions with external types file import 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
+import { ABCType, Avatar, UpdateUserInput, User, ABCStatus, Status } from './types/graphql';
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
@@ -65,15 +66,84 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
+    };
+};
+"
+`;
+
+exports[`should generate mock data with as-is enum if enumValues is "keep" 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.hasABCStatus,
+    };
+};
+"
+`;
+
+exports[`should generate mock data with as-is types if typenames is "keep" 1`] = `
+"
+export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : ABCStatus.HasAbcStatus,
     };
 };
 "
 `;
 
 exports[`should generate mock data with pascalCase enum if enumValues is "pascal-case#pascalCase" 1`] = `
-"/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
-
+"
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
@@ -101,6 +171,42 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
+    };
+};
+"
+`;
+
+exports[`should generate mock data with pascalCase types by default 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
     };
 };
 "
@@ -108,7 +214,7 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data with typename if addTypename is true 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
+import { ABCType, Avatar, UpdateUserInput, User, ABCStatus, Status } from './types/graphql';
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
@@ -140,15 +246,14 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HasAbcStatus,
     };
 };
 "
 `;
 
 exports[`should generate mock data with upperCase enum if enumValues is "upper-case#upperCase" 1`] = `
-"/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';
-
+"
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
@@ -176,6 +281,42 @@ export const aUser = (overrides?: Partial<User>): User => {
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : AbcStatus.HASABCSTATUS,
+    };
+};
+"
+`;
+
+exports[`should generate mock data with upperCase types if typenames is "upper-case#upperCase" 1`] = `
+"
+export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>): UPDATEUSERINPUT => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUSER = (overrides?: Partial<USER>): USER => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
+        abcStatus: overrides && overrides.hasOwnProperty('abcStatus') ? overrides.abcStatus! : ABCSTATUS.HasAbcStatus,
     };
 };
 "

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -55,7 +55,7 @@ it('should generate mock data functions with external types file import', async 
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts' });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Avatar, UpdateUserInput, User, Status } from './types/graphql';");
+    expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
 
@@ -63,7 +63,7 @@ it('should generate mock data with typename if addTypename is true', async () =>
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts', addTypename: true });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Avatar, UpdateUserInput, User, Status } from './types/graphql';");
+    expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
 
@@ -74,7 +74,7 @@ it('should generate mock data with pascalCase enum if enumValues is "pascal-case
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Avatar, UpdateUserInput, User, Status } from './types/graphql';");
+    expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
 
@@ -85,7 +85,7 @@ it('should generate mock data with upperCase enum if enumValues is "upper-case#u
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Avatar, UpdateUserInput, User, Status } from './types/graphql';");
+    expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
 

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -14,7 +14,7 @@ const testSchema = buildSchema(/* GraphQL */ `
         login: String!
         avatar: Avatar
         status: Status!
-        abcStatus: ABCStatus
+        customStatus: ABCStatus
     }
 
     type Query {
@@ -37,7 +37,7 @@ const testSchema = buildSchema(/* GraphQL */ `
     }
 
     enum ABCStatus {
-        hasABCStatus
+        hasXYZStatus
     }
 
     type Mutation {
@@ -67,54 +67,89 @@ it('should generate mock data functions with external types file import', async 
 });
 
 it('should generate mock data with typename if addTypename is true', async () => {
-    const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts', addTypename: true });
+    const result = await plugin(testSchema, [], { addTypename: true });
 
     expect(result).toBeDefined();
+    expect(result).toContain('__typename');
     expect(result).toMatchSnapshot();
 });
 
-it('should generate mock data with pascalCase enum if enumValues is "pascal-case#pascalCase"', async () => {
-    const result = await plugin(testSchema, [], { enumValues: 'pascal-case#pascalCase' });
-
-    expect(result).toBeDefined();
-    expect(result).toMatchSnapshot();
-});
-
-it('should generate mock data with upperCase enum if enumValues is "upper-case#upperCase"', async () => {
-    const result = await plugin(testSchema, [], { enumValues: 'upper-case#upperCase' });
-
-    expect(result).toBeDefined();
-    expect(result).toMatchSnapshot();
-});
-
-it('should generate mock data with as-is enum if enumValues is "keep"', async () => {
-    const result = await plugin(testSchema, [], { enumValues: 'keep' });
-
-    expect(result).toBeDefined();
-    expect(result).toMatchSnapshot();
-});
-
-it('should generate mock data with pascalCase types by default', async () => {
+it('should generate mock data with pascalCase enum values by default', async () => {
     const result = await plugin(testSchema, [], {});
 
     expect(result).toBeDefined();
+    expect(result).toContain('HasXyzStatus');
+    expect(result).not.toContain('hasXYZStatus');
+    expect(result).not.toContain('HASXYZSTATUS');
     expect(result).toMatchSnapshot();
 });
 
-it('should generate mock data with upperCase types if typenames is "upper-case#upperCase"', async () => {
-    const result = await plugin(testSchema, [], {
-        typenames: 'upper-case#upperCase',
-    });
+it('should generate mock data with pascalCase enum values if enumValues is "pascal-case#pascalCase"', async () => {
+    const result = await plugin(testSchema, [], { enumValues: 'pascal-case#pascalCase' });
 
     expect(result).toBeDefined();
+    expect(result).toContain('HasXyzStatus');
+    expect(result).not.toContain('hasXYZStatus');
+    expect(result).not.toContain('HASXYZSTATUS');
     expect(result).toMatchSnapshot();
 });
 
-it('should generate mock data with as-is types if typenames is "keep"', async () => {
-    const result = await plugin(testSchema, [], {
-        typenames: 'keep',
-    });
+it('should generate mock data with upperCase enum values if enumValues is "upper-case#upperCase"', async () => {
+    const result = await plugin(testSchema, [], { enumValues: 'upper-case#upperCase' });
 
     expect(result).toBeDefined();
+    expect(result).not.toContain('HasXyzStatus');
+    expect(result).not.toContain('hasXYZStatus');
+    expect(result).toContain('HASXYZSTATUS');
+    expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with as-is enum values if enumValues is "keep"', async () => {
+    const result = await plugin(testSchema, [], { enumValues: 'keep' });
+
+    expect(result).toBeDefined();
+    expect(result).not.toContain('HasXyzStatus');
+    expect(result).toContain('hasXYZStatus');
+    expect(result).not.toContain('HASXYZSTATUS');
+    expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with pascalCase types and enums by default', async () => {
+    const result = await plugin(testSchema, [], {});
+
+    expect(result).toBeDefined();
+    expect(result).toMatch(/Abc(Type|Status)/);
+    expect(result).not.toMatch(/ABC(Type|Status)/);
+    expect(result).not.toMatch(/ABC(TYPE|STATUS)/);
+    expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with pascalCase enum values if typenames is "pascal-case#pascalCase"', async () => {
+    const result = await plugin(testSchema, [], { typenames: 'pascal-case#pascalCase' });
+
+    expect(result).toBeDefined();
+    expect(result).toMatch(/Abc(Type|Status)/);
+    expect(result).not.toMatch(/ABC(Type|Status)/);
+    expect(result).not.toMatch(/ABC(TYPE|STATUS)/);
+    expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with upperCase types and enums if typenames is "upper-case#upperCase"', async () => {
+    const result = await plugin(testSchema, [], { typenames: 'upper-case#upperCase' });
+
+    expect(result).toBeDefined();
+    expect(result).not.toMatch(/Abc(Type|Status)/);
+    expect(result).not.toMatch(/ABC(Type|Status)/);
+    expect(result).toMatch(/ABC(TYPE|STATUS)/);
+    expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with as-is types and enums if typenames is "keep"', async () => {
+    const result = await plugin(testSchema, [], { typenames: 'keep' });
+
+    expect(result).toBeDefined();
+    expect(result).not.toMatch(/Abc(Type|Status)/);
+    expect(result).toMatch(/ABC(Type|Status)/);
+    expect(result).not.toMatch(/ABC(TYPE|STATUS)/);
     expect(result).toMatchSnapshot();
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -89,12 +89,12 @@ it('should generate mock data with upperCase enum if enumValues is "upper-case#u
     expect(result).toMatchSnapshot();
 });
 
-it('should generate mock data with pascalCase types', async () => {
+it('should generate mock data with pascalCase types by default', async () => {
     const result = await plugin(testSchema, [], {});
 
     expect(result).toBeDefined();
-    expect(result).toContain('ABCType');
-    expect(result).toContain('anABCType');
-    expect(result).not.toContain('AbcType');
-    expect(result).not.toContain('anAbcType');
+    expect(result).toContain('AbcType');
+    expect(result).toContain('anAbcType');
+    expect(result).not.toContain('ABCType');
+    expect(result).not.toContain('anABCType');
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -33,6 +33,7 @@ const testSchema = buildSchema(/* GraphQL */ `
     enum Status {
         ONLINE
         OFFLINE
+        isAFK
     }
 
     type Mutation {
@@ -87,6 +88,17 @@ it('should generate mock data with upperCase enum if enumValues is "upper-case#u
     expect(result).toBeDefined();
     expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with as-is enum if enumValues is "keep"', async () => {
+    const result = await plugin(testSchema, [], {
+        enumValues: 'keep',
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toContain('isAFK');
+    expect(result).not.toContain('isAfK');
+    expect(result).not.toContain('ISAFK');
 });
 
 it('should generate mock data with pascalCase types by default', async () => {

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -14,6 +14,7 @@ const testSchema = buildSchema(/* GraphQL */ `
         login: String!
         avatar: Avatar
         status: Status!
+        abcStatus: ABCStatus
     }
 
     type Query {
@@ -33,7 +34,10 @@ const testSchema = buildSchema(/* GraphQL */ `
     enum Status {
         ONLINE
         OFFLINE
-        isAFK
+    }
+
+    enum ABCStatus {
+        hasABCStatus
     }
 
     type Mutation {
@@ -56,7 +60,9 @@ it('should generate mock data functions with external types file import', async 
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts' });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
+    expect(result).toContain(
+        "import { ABCType, Avatar, UpdateUserInput, User, ABCStatus, Status } from './types/graphql';",
+    );
     expect(result).toMatchSnapshot();
 });
 
@@ -64,50 +70,35 @@ it('should generate mock data with typename if addTypename is true', async () =>
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts', addTypename: true });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
 
 it('should generate mock data with pascalCase enum if enumValues is "pascal-case#pascalCase"', async () => {
-    const result = await plugin(testSchema, [], {
-        enumValues: 'pascal-case#pascalCase',
-        typesFile: './types/graphql.ts',
-    });
+    const result = await plugin(testSchema, [], { enumValues: 'pascal-case#pascalCase' });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
 
 it('should generate mock data with upperCase enum if enumValues is "upper-case#upperCase"', async () => {
-    const result = await plugin(testSchema, [], {
-        enumValues: 'upper-case#upperCase',
-        typesFile: './types/graphql.ts',
-    });
+    const result = await plugin(testSchema, [], { enumValues: 'upper-case#upperCase' });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { ABCType, Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
 });
 
 it('should generate mock data with as-is enum if enumValues is "keep"', async () => {
-    const result = await plugin(testSchema, [], {
-        enumValues: 'keep',
-    });
+    const result = await plugin(testSchema, [], { enumValues: 'keep' });
 
     expect(result).toBeDefined();
-    expect(result).toContain('isAFK');
-    expect(result).not.toContain('isAfK');
-    expect(result).not.toContain('ISAFK');
+    expect(result).toMatchSnapshot();
 });
 
 it('should generate mock data with pascalCase types by default', async () => {
     const result = await plugin(testSchema, [], {});
 
     expect(result).toBeDefined();
-    expect(result).toContain('AbcType');
-    expect(result).not.toContain('ABCType');
-    expect(result).not.toContain('ABCTYPE');
+    expect(result).toMatchSnapshot();
 });
 
 it('should generate mock data with upperCase types if typenames is "upper-case#upperCase"', async () => {
@@ -116,9 +107,7 @@ it('should generate mock data with upperCase types if typenames is "upper-case#u
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain('ABCTYPE');
-    expect(result).not.toContain('AbcType');
-    expect(result).not.toContain('ABCType');
+    expect(result).toMatchSnapshot();
 });
 
 it('should generate mock data with as-is types if typenames is "keep"', async () => {
@@ -127,7 +116,5 @@ it('should generate mock data with as-is types if typenames is "keep"', async ()
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain('ABCType');
-    expect(result).not.toContain('AbcType');
-    expect(result).not.toContain('ABCTYPE');
+    expect(result).toMatchSnapshot();
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -98,9 +98,9 @@ it('should generate mock data with pascalCase types by default', async () => {
     expect(result).not.toContain('ABCTYPE');
 });
 
-it('should generate mock data with upperCase types if typenameValues is "upper-case#upperCase"', async () => {
+it('should generate mock data with upperCase types if typenames is "upper-case#upperCase"', async () => {
     const result = await plugin(testSchema, [], {
-        typenameValues: 'upper-case#upperCase',
+        typenames: 'upper-case#upperCase',
     });
 
     expect(result).toBeDefined();
@@ -109,9 +109,9 @@ it('should generate mock data with upperCase types if typenameValues is "upper-c
     expect(result).not.toContain('ABCType');
 });
 
-it('should generate mock data with as-is types if typenameValues is "keep"', async () => {
+it('should generate mock data with as-is types if typenames is "keep"', async () => {
     const result = await plugin(testSchema, [], {
-        typenameValues: 'keep',
+        typenames: 'keep',
     });
 
     expect(result).toBeDefined();

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -94,9 +94,8 @@ it('should generate mock data with pascalCase types by default', async () => {
 
     expect(result).toBeDefined();
     expect(result).toContain('AbcType');
-    expect(result).toContain('anAbcType');
     expect(result).not.toContain('ABCType');
-    expect(result).not.toContain('anABCType');
+    expect(result).not.toContain('ABCTYPE');
 });
 
 it('should generate mock data with upperCase types if typenameValues is "upper-case#upperCase"', async () => {
@@ -106,9 +105,17 @@ it('should generate mock data with upperCase types if typenameValues is "upper-c
 
     expect(result).toBeDefined();
     expect(result).toContain('ABCTYPE');
-    expect(result).toContain('anABCTYPE');
     expect(result).not.toContain('AbcType');
-    expect(result).not.toContain('anAbcType');
     expect(result).not.toContain('ABCType');
-    expect(result).not.toContain('anABCType');
+});
+
+it('should generate mock data with as-is types if typenameValues is "keep"', async () => {
+    const result = await plugin(testSchema, [], {
+        typenameValues: 'keep',
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toContain('ABCType');
+    expect(result).not.toContain('AbcType');
+    expect(result).not.toContain('ABCTYPE');
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -20,6 +20,10 @@ const testSchema = buildSchema(/* GraphQL */ `
         user: User!
     }
 
+    type ABCType {
+        abc: String!
+    }
+
     input UpdateUserInput {
         id: ID!
         login: String
@@ -83,4 +87,12 @@ it('should generate mock data with upperCase enum if enumValues is "upper-case#u
     expect(result).toBeDefined();
     expect(result).toContain("import { Avatar, UpdateUserInput, User, Status } from './types/graphql';");
     expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with pascalCase types', async () => {
+    const result = await plugin(testSchema, [], {});
+
+    expect(result).toBeDefined();
+    expect(result).toContain('ABCType');
+    expect(result).not.toContain('AbcType');
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -94,5 +94,7 @@ it('should generate mock data with pascalCase types', async () => {
 
     expect(result).toBeDefined();
     expect(result).toContain('ABCType');
+    expect(result).toContain('anABCType');
     expect(result).not.toContain('AbcType');
+    expect(result).not.toContain('anAbcType');
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -98,3 +98,17 @@ it('should generate mock data with pascalCase types by default', async () => {
     expect(result).not.toContain('ABCType');
     expect(result).not.toContain('anABCType');
 });
+
+it('should generate mock data with upperCase types if typenameValues is "upper-case#upperCase"', async () => {
+    const result = await plugin(testSchema, [], {
+        typenameValues: 'upper-case#upperCase',
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toContain('ABCTYPE');
+    expect(result).toContain('anABCTYPE');
+    expect(result).not.toContain('AbcType');
+    expect(result).not.toContain('anAbcType');
+    expect(result).not.toContain('ABCType');
+    expect(result).not.toContain('anABCType');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.25.0.tgz#1147225d4763282a98abf4cbbc0e324eee4b038d"
   integrity sha512-XUgJir4roCPdUUX/5wo26dyj1eFZbYKIjP1SuVJDskZ4x3HOwhggBK5WBKkJFv5rGrWnAtVfZpOju4Qzez7GgQ==
 
-"@auto-it/bot-list@^9.25.2":
-  version "9.25.2"
-  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.25.2.tgz#98b912dd24d021ab83aa2a6c5903aacada6ff2bd"
-  integrity sha512-LEdvOElACCeAnNxp4p0AgxVKCaWAt92dPFRNR44kfTaH2q9L4K4lx2bEGIiLBVDbvr6gBV3iz/sqPmPpzOWeIA==
+"@auto-it/bot-list@^9.39.0":
+  version "9.39.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.39.0.tgz#cdfca23b47918ab988f99d08d1214d3754cd1ea5"
+  integrity sha512-MEEUmqi0tIR6vkvErpgEbzCKK9BHVYd4GGe9vKNxH8BffhZi2br9EOCMZTb494SdTpP8hV8e36jCMZdx1g/gZA==
 
 "@auto-it/conventional-commits@^9.25.0":
   version "9.25.0"
@@ -61,36 +61,35 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/core@^9.25.2":
-  version "9.25.2"
-  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.25.2.tgz#6fe60b332d1327e5549b35b75b85316ef3cd4ae5"
-  integrity sha512-HWhB4WTvveKRGFrcIEOFxhtZHNeNT1ex8csb2J1c1r/94ZakcDkXS1K8d0ynSuRGbthEJA7kJiZ9pTwwyjmS4w==
+"@auto-it/core@^9.39.0":
+  version "9.39.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.39.0.tgz#41c5f4e91a556b07fe73710b7d5be3a1e65a3dde"
+  integrity sha512-l8dGrN58cWob6MHnnLF+iT0HYSDVJS2ZwkNsidH0NtgAQUNoU22bDpxSXxqrXCwZ9epUwI9E9BOTx8nXkUXOAw==
   dependencies:
-    "@auto-it/bot-list" "^9.25.2"
-    "@octokit/core" "2.4.2"
-    "@octokit/graphql" "4.3.1"
-    "@octokit/plugin-enterprise-compatibility" "1.2.2"
-    "@octokit/plugin-retry" "3.0.1"
+    "@auto-it/bot-list" "^9.39.0"
+    "@octokit/graphql" "^4.4.0"
+    "@octokit/plugin-enterprise-compatibility" "^1.2.2"
+    "@octokit/plugin-retry" "^3.0.1"
     "@octokit/plugin-throttling" "^3.2.0"
-    "@octokit/rest" "16.43.1"
+    "@octokit/rest" "^17.9.0"
     await-to-js "^2.1.1"
-    chalk "^3.0.0"
+    chalk "^4.0.0"
     cosmiconfig "6.0.0"
     deepmerge "^4.0.0"
     dotenv "^8.0.0"
-    endent "^1.3.0"
+    endent "^2.0.1"
     enquirer "^2.3.4"
     env-ci "^5.0.1"
     fast-glob "^3.1.1"
     fp-ts "^2.5.3"
     fromentries "^1.2.0"
-    gitlogplus "^3.1.2"
+    gitlog "^4.0.0"
     https-proxy-agent "^5.0.0"
     import-cwd "^3.0.0"
     import-from "^3.0.0"
     io-ts "^2.1.2"
     lodash.chunk "^4.2.0"
-    log-symbols "^3.0.0"
+    log-symbols "^4.0.0"
     node-fetch "2.6.0"
     parse-github-url "1.0.2"
     semver "^7.0.0"
@@ -102,12 +101,13 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/npm@^9.25.2":
-  version "9.25.2"
-  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.25.2.tgz#7f69356e067f47e58255b84b47b5e5449d9d1619"
-  integrity sha512-Jj9ml8daM8K2gWILdD9mbGTsf3RmXbbVwn/5PdZqozCFllGwElLZFCHNeuujGwOCqg3ZV46+MNtbP0UTB4g7nA==
+"@auto-it/npm@^9.39.0":
+  version "9.39.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.39.0.tgz#165069c5d5942aaf126e30ce4f7e3fffca122b7f"
+  integrity sha512-ktjspMTnSvZThYB9m36uS4+hAkBm8FdvIQbaiCUypDduzUnWtrwnV2ZhLR3KG3GyFkCgpAzYnxKY6OugQJ/U1w==
   dependencies:
-    "@auto-it/core" "^9.25.2"
+    "@auto-it/core" "^9.39.0"
+    await-to-js "^2.1.1"
     env-ci "^5.0.1"
     fp-ts "^2.5.3"
     get-monorepo-packages "^1.1.0"
@@ -121,12 +121,12 @@
     url-join "^4.0.0"
     user-home "^2.0.0"
 
-"@auto-it/released@^9.25.2":
-  version "9.25.2"
-  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.25.2.tgz#67a1760cdaf1c44a3802ea807d20490c305a8769"
-  integrity sha512-vd73DqIvyv1u3DQgUx3nk0F5XPYRzEoojBMWCtBSATwuoVcWpHFjC9vG5ZhyL1UejHeo8+GCVwEfYLH7apZPGA==
+"@auto-it/released@^9.39.0":
+  version "9.39.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.39.0.tgz#d5502191bc7a72cee4b3fca25f37f415dec19238"
+  integrity sha512-5nHQ76dJV8SS1rS/Ro7R4ZVjLqwaGS/Fp2vWgd+XbgR2MGNgQwW0PsaaHHFzbxqt2Pen1EeFwB0gPVUgsH1Wtg==
   dependencies:
-    "@auto-it/core" "^9.25.2"
+    "@auto-it/core" "^9.39.0"
     deepmerge "^4.0.0"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
@@ -731,12 +731,33 @@
     before-after-hook "^2.1.0"
     universal-user-agent "^5.0.0"
 
+"@octokit/core@^2.4.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-2.5.3.tgz#dd754e6f5ad9b15631e9b276ae4f00ac2ea2cf9b"
+  integrity sha512-23AHK9xBW0v79Ck8h5U+5iA4MW7aosqv+Yr6uZXolVGNzzHwryNH5wM386/6+etiKUTwLFZTqyMU9oQpIBZcFA==
+  dependencies:
+    "@octokit/auth-token" "^2.4.0"
+    "@octokit/graphql" "^4.3.1"
+    "@octokit/request" "^5.4.0"
+    "@octokit/types" "^4.0.1"
+    before-after-hook "^2.1.0"
+    universal-user-agent "^5.0.0"
+
 "@octokit/endpoint@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.0.tgz#4c7acd79ab72df78732a7d63b09be53ec5a2230b"
   integrity sha512-3nx+MEYoZeD0uJ+7F/gvELLvQJzLXhep2Az0bBSXagbApDvDW0LWwpnAIY/hb0Jwe17A0fJdz0O12dPh05cj7A==
   dependencies:
     "@octokit/types" "^2.0.0"
+    is-plain-object "^3.0.0"
+    universal-user-agent "^5.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.2.tgz#e876aafe68d7f9b6c6d80bf29458403f9afe7b2b"
+  integrity sha512-xs1mmCEZ2y4shXCpFjNq3UbmNR+bLzxtZim2L0zfEtj9R6O6kc4qLDvYw66hvO6lUsYzPTM5hMkltbuNAbRAcQ==
+  dependencies:
+    "@octokit/types" "^4.0.1"
     is-plain-object "^3.0.0"
     universal-user-agent "^5.0.0"
 
@@ -749,6 +770,15 @@
     "@octokit/types" "^2.0.0"
     universal-user-agent "^4.0.0"
 
+"@octokit/graphql@^4.4.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.0.tgz#e111f841bc15722b1e9887f447fccab700cacdad"
+  integrity sha512-StJWfn0M1QfhL3NKBz31e1TdDNZrHLLS57J2hin92SIfzlOVBuUaRkp31AGkGOAFOAVtyEX6ZiZcsjcJDjeb5g==
+  dependencies:
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^4.0.1"
+    universal-user-agent "^5.0.0"
+
 "@octokit/plugin-enterprise-compatibility@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.2.tgz#a30b635b63760e1504e57af5cf54da058b32a1de"
@@ -757,12 +787,27 @@
     "@octokit/request-error" "^2.0.0"
     "@octokit/types" "^2.0.1"
 
+"@octokit/plugin-enterprise-compatibility@^1.2.2":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-1.2.4.tgz#617ab902b571cf3fd01e99f33850590fbc297638"
+  integrity sha512-NN9U8bR0xWK5VeimTuk7kzQkPGFdICF0+7Oj5MYwbpr6IKu63Sp/aSNzhV7Q7bNasHC8mCHTyftAufrrzazJGQ==
+  dependencies:
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^4.0.1"
+
 "@octokit/plugin-paginate-rest@^1.1.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz#004170acf8c2be535aba26727867d692f7b488fc"
   integrity sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==
   dependencies:
     "@octokit/types" "^2.0.1"
+
+"@octokit/plugin-paginate-rest@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.1.tgz#b95ec46c841d51e5e625f383c579d132ab216d05"
+  integrity sha512-/tHpIF2XpN40AyhIq295YRjb4g7Q5eKob0qM3thYJ0Z+CgmNsWKM/fWse/SUR8+LdprP1O4ZzSKQE+71TCwK+w==
+  dependencies:
+    "@octokit/types" "^4.0.1"
 
 "@octokit/plugin-request-log@^1.0.0":
   version "1.0.0"
@@ -777,12 +822,28 @@
     "@octokit/types" "^2.0.1"
     deprecation "^2.3.1"
 
+"@octokit/plugin-rest-endpoint-methods@3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.15.0.tgz#2f01bf16a1fd2fb8ec8915aebc4d4b5b348ea8d6"
+  integrity sha512-cx4JScYv3rA7pR9gCd8SBdf8LtkIYsN6Jtl0O0pG1IrKaj/HVz1b27zFaS5gn/MI8UwdDtUuHiN3NMtkrIWoqA==
+  dependencies:
+    "@octokit/types" "^4.1.6"
+    deprecation "^2.3.1"
+
 "@octokit/plugin-retry@3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.1.tgz#4f17e4349b89754fd06951b548f08e2d8e7dd311"
   integrity sha512-X+VALkeYyE4XGMHOoOnRS1/OvwvleZ2Xe3yxshaAKJrA4pbjBYptDx7IAY9xQj5JYY9vlCKUsXEZMWLRNxfViw==
   dependencies:
     "@octokit/types" "^2.0.1"
+    bottleneck "^2.15.3"
+
+"@octokit/plugin-retry@^3.0.1":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-retry/-/plugin-retry-3.0.2.tgz#1055728d1d0e25287ef3cc30bf3321c942bf44a4"
+  integrity sha512-k7xl2WLfLP7WirRXRHtCq5xGAIXBZHV9X3HVUJhPwe8/N8vVzxPcnnnBL5NpEep/+GQqFRdYxrkgz68VY3z2wA==
+  dependencies:
+    "@octokit/types" "^4.0.1"
     bottleneck "^2.15.3"
 
 "@octokit/plugin-throttling@^3.2.0":
@@ -825,6 +886,20 @@
     once "^1.4.0"
     universal-user-agent "^5.0.0"
 
+"@octokit/request@^5.4.0":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.4.tgz#dc57e85e86284fa016d0c1a2701a70a10cec4ff2"
+  integrity sha512-vqv1lz41c6VTxUvF9nM+a6U+vvP3vGk7drDpr0DVQg4zyqlOiKVrY17DLD6de5okj+YLHKcoqaUZTBtlNZ1BtQ==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^4.0.1"
+    deprecation "^2.0.0"
+    is-plain-object "^3.0.0"
+    node-fetch "^2.3.0"
+    once "^1.4.0"
+    universal-user-agent "^5.0.0"
+
 "@octokit/rest@16.43.1":
   version "16.43.1"
   resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.43.1.tgz#3b11e7d1b1ac2bbeeb23b08a17df0b20947eda6b"
@@ -847,10 +922,27 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
+"@octokit/rest@^17.9.0":
+  version "17.10.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-17.10.0.tgz#40d94e8abb98741aa99d0dac39a974cd257f7865"
+  integrity sha512-TT0rsmi/IhYDy37+roEjawvpUfXxXVLWjWfcoOByJ8eQka1N21ka7BqVCi+rWco4x7sSffXcw2QfGmmNSUb7Tw==
+  dependencies:
+    "@octokit/core" "^2.4.3"
+    "@octokit/plugin-paginate-rest" "^2.2.0"
+    "@octokit/plugin-request-log" "^1.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "3.15.0"
+
 "@octokit/types@^2.0.0", "@octokit/types@^2.0.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.5.1.tgz#22563b3bb50034bea3176eac1860340c5e812e2a"
   integrity sha512-q4Wr7RexkPRrkQpXzUYF5Fj/14Mr65RyOHj6B9d/sQACpqGcStkHZj4qMEtlMY5SnD/69jlL9ItGPbDM0dR/dA==
+  dependencies:
+    "@types/node" ">= 8"
+
+"@octokit/types@^4.0.1", "@octokit/types@^4.1.6":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-4.1.7.tgz#efb1c26b6e6201b7d6e56b9a17e73d0541401567"
+  integrity sha512-2ydXNFLsoJbm5D3zvAkbK0y9JaS4eBZ4sk0DJcOLH1sY+p3H861ysARJLLQQtztN5y5vvxKS12JRUwoLkEO4Ag==
   dependencies:
     "@types/node" ">= 8"
 
@@ -1343,18 +1435,18 @@ author-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
   integrity sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=
 
-auto@^9.25.1:
-  version "9.25.2"
-  resolved "https://registry.yarnpkg.com/auto/-/auto-9.25.2.tgz#2b17831c61672a6e7a50ef571cdfd6cc82b8b812"
-  integrity sha512-TnW/aS204QdPUYri3oSD1+5M3I3Qx2T3gIFHe2ZA5L8ssVwk2YQ3BLnyux3+l4oDB3ystUcDupLGjngOUWjkeA==
+auto@^9.26.0:
+  version "9.39.0"
+  resolved "https://registry.yarnpkg.com/auto/-/auto-9.39.0.tgz#1cf174541ea1d3a7432d315fed521fd4d15154c1"
+  integrity sha512-ebJXsceHcZKM3h2erTxkMnGjnypruS0xHLJEHi9GIB8+yVe/6Iwz/qeNcUelemzmJzenqv0wH+fJE2kikuQVqw==
   dependencies:
-    "@auto-it/core" "^9.25.2"
-    "@auto-it/npm" "^9.25.2"
-    "@auto-it/released" "^9.25.2"
+    "@auto-it/core" "^9.39.0"
+    "@auto-it/npm" "^9.39.0"
+    "@auto-it/released" "^9.39.0"
     await-to-js "^2.1.1"
-    chalk "^3.0.0"
+    chalk "^4.0.0"
     command-line-application "^0.9.3"
-    endent "^1.3.0"
+    endent "^2.0.1"
     module-alias "^2.2.2"
     signale "^1.4.0"
     terminal-link "^2.1.1"
@@ -1594,6 +1686,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2090,6 +2190,15 @@ endent@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/endent/-/endent-1.4.1.tgz#c58cc13dfc432d0b2c7faf74c13ffdca60b2d1c8"
   integrity sha512-buHTb5c8AC9NshtP6dgmNLYkiT+olskbq1z6cEGvfGCF3Qphbu/1zz5Xu+yjTDln8RbxNhPoUyJ5H8MSrp1olQ==
+  dependencies:
+    dedent "^0.7.0"
+    fast-json-parse "^1.0.3"
+    objectorarray "^1.0.4"
+
+endent@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/endent/-/endent-2.0.1.tgz#fb18383a3f37ae3213a5d9f6c4a880d1061eb4c5"
+  integrity sha512-mADztvcC+vCk4XEZaCz6xIPO2NHQuprv5CAEjuVAu6aZwqAj7nVNlMyl1goPFYqCCpS2OJV9jwpumJLkotZrNw==
   dependencies:
     dedent "^0.7.0"
     fast-json-parse "^1.0.3"
@@ -2748,6 +2857,14 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+gitlog@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/gitlog/-/gitlog-4.0.0.tgz#c4f440c822cc3fe1b32366d0662918871d3c7249"
+  integrity sha512-N6ZcvvbHsqhmM09wtzbL8v3FPwBK3EQ1xnv/2nj9JGH/YsYVn+ZkmMCxzkEjHnSFcpUk2HN2LBp76PGj3TkPag==
+  dependencies:
+    debug "^4.1.1"
+    tslib "^1.11.1"
 
 gitlogplus@^3.1.2:
   version "3.1.7"
@@ -4096,6 +4213,13 @@ log-symbols@^3.0.0:
   dependencies:
     chalk "^2.4.2"
 
+log-symbols@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
+  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+  dependencies:
+    chalk "^4.0.0"
+
 log-update@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
@@ -4256,12 +4380,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@1.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mkdirp@^0.5.1:
+mkdirp@0.x, mkdirp@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -5071,7 +5190,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.3.2:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -5786,10 +5905,10 @@ ts-invariant@^0.4.0:
   dependencies:
     tslib "^1.9.3"
 
-ts-jest@^25.3.1:
-  version "25.3.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.3.1.tgz#58e2ed3506e4e4487c0b9b532846a5cade9656ba"
-  integrity sha512-O53FtKguoMUByalAJW+NWEv7c4tus5ckmhfa7/V0jBb2z8v5rDSLFC1Ate7wLknYPC1euuhY6eJjQq4FtOZrkg==
+ts-jest@^25.4.0:
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.5.1.tgz#2913afd08f28385d54f2f4e828be4d261f4337c7"
+  integrity sha512-kHEUlZMK8fn8vkxDjwbHlxXRB9dHYpyzqKIGDNxbzs+Rz+ssNDSDNusEK8Fk/sDd4xE6iKoQLfFkFVaskmTJyw==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"
@@ -5798,8 +5917,7 @@ ts-jest@^25.3.1:
     lodash.memoize "4.x"
     make-error "1.x"
     micromatch "4.x"
-    mkdirp "1.x"
-    resolve "1.x"
+    mkdirp "0.x"
     semver "6.x"
     yargs-parser "18.x"
 
@@ -5812,6 +5930,11 @@ tslib@1.11.1, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^1.11.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
* Default casing of typenames to pascalCase for consistency with the `typescript` plugin - **this is a breaking change**
* Add configuration option `typenames` to allow customization of typenames casing
* Add `keep` value for preserving original casing of both enum values and typenames. Users who rely on the current behavior can use it to avoid having to adjust their code
* Adjust existing unit tests and add new ones
* Update doc

Consider bumping the version number to 0.4.0