### PR TITLE
feat:  add `scalars` config option for custom GraphQL [scalar -> casual] mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Changes the case of the enums. Accepts `upper-case#upperCase`, `pascal-case#pasc
 
 Changes the case of the enums. Accepts `upper-case#upperCase`, `pascal-case#pascalCase` or `keep`
 
+### scalars (`{ [Scalar: string]: keyof Casual.Casual | Casual.functions }`, defaultValue: `undefined`)
+
+Allows you to define mappings for your custom scalars. Allows you to map any GraphQL Scalar to a
+ [casual](https://github.com/boo1ean/casual#embedded-generators) embedded generator (string or
+ function key)
+
 ## Example of usage
 
 **codegen.yml**
@@ -43,6 +49,8 @@ generates:
           typesFile: '../generated-types.ts'
           enumValues: upper-case#upperCase
           typenames: keep
+          scalars:
+            AWSTimestamp: unix_time # gets translated to casual.unix_time
 ```
 
 ## Example or generated code
@@ -50,6 +58,8 @@ generates:
 Given the following schema:
 
 ```graphql
+scalar AWSTimestamp
+
 type Avatar {
   id: ID!
   url: String!
@@ -60,6 +70,7 @@ type User {
   login: String!
   avatar: Avatar
   status: Status!
+  updatedAt: AWSTimestamp
 }
 
 type Query {
@@ -106,6 +117,7 @@ export const aUser = (overrides?: Partial<User>): User => {
     login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
     avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+    updatedAt: overrides && overrides.hasOwnProperty('updatedAt') ? overrides.updatedAt! : 1458071232,
   };
 };
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,9 @@ const getNamedType = (
                         }
 
                         // If there is a mapping to a `casual` type, then use this
-                        const value = casual[customScalars[foundType.name]];
-                        return typeof value === 'function' ? value() : value;
+                        const embeddedGenerator = casual[customScalars[foundType.name]];
+                        const value = typeof embeddedGenerator === 'function' ? embeddedGenerator() : embeddedGenerator;
+                        return typeof value === 'string' ? `'${value}'` : value;
                     default:
                         throw `foundType is unknown: ${foundType.name}: ${foundType.type}`;
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,10 +108,18 @@ const getNamedType = (
                             return `'${casual.word}'`;
                         }
 
-                        // If there is a mapping to a `casual` type, then use this
+                        // If there is a mapping to a `casual` type, then use it and make sure
+                        // to call it if it's a function
                         const embeddedGenerator = casual[customScalars[foundType.name]];
                         const value = typeof embeddedGenerator === 'function' ? embeddedGenerator() : embeddedGenerator;
-                        return typeof value === 'string' ? `'${value}'` : value;
+
+                        if (typeof value === 'string') {
+                            return `'${value}'`;
+                        }
+                        if (typeof value === 'object') {
+                            return `${JSON.stringify(value)}`;
+                        }
+                        return value;
                     default:
                         throw `foundType is unknown: ${foundType.name}: ${foundType.type}`;
                 }

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -480,7 +480,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : Mohamed.Nader@Kiehn.io,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io',
     };
 };
 "

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should correctly generate the \`casual\` data for a non-string scalar mapping 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'America/Maceio',
+    };
+};
+"
+`;
+
+exports[`should correctly generate the \`casual\` data for a scalar mapping of type string 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io',
+    };
+};
+"
+`;
+
 exports[`should generate mock data functions 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
@@ -444,43 +518,6 @@ export const aUSER = (overrides?: Partial<USER>): USER => {
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-    };
-};
-"
-`;
-
-exports[`should generate the \`casual\` data for a particular scalar mapping 1`] = `
-"
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
-    };
-};
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
-    };
-};
-
-export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-    };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io',
     };
 };
 "

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -31,7 +31,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'America/Maceio',
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,98,185],
     };
 };
 "

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -448,3 +448,40 @@ export const aUSER = (overrides?: Partial<USER>): USER => {
 };
 "
 `;
+
+exports[`should generate the \`casual\` data for a particular scalar mapping 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : Mohamed.Nader@Kiehn.io,
+    };
+};
+"
+`;

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -169,11 +169,18 @@ it('should generate mock data with as-is types and enums if typenames is "keep"'
     expect(result).toMatchSnapshot();
 });
 
-it('should generate the `casual` data for a particular scalar mapping', async () => {
+it('should correctly generate the `casual` data for a scalar mapping of type string', async () => {
     const result = await plugin(testSchema, [], { scalars: { AnyObject: 'email' } });
 
-    const emailRegex = /(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
     expect(result).toBeDefined();
-    expect(emailRegex.test(result as string)).toBeTruthy();
+    expect(result).toContain('Mohamed.Nader@Kiehn.io');
+    expect(result).toMatchSnapshot();
+});
+
+it('should correctly generate the `casual` data for a non-string scalar mapping', async () => {
+    const result = await plugin(testSchema, [], { scalars: { AnyObject: 'timezone' } });
+
+    expect(result).toBeDefined();
+    expect(result).toContain('America/Maceio');
     expect(result).toMatchSnapshot();
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -178,9 +178,9 @@ it('should correctly generate the `casual` data for a scalar mapping of type str
 });
 
 it('should correctly generate the `casual` data for a non-string scalar mapping', async () => {
-    const result = await plugin(testSchema, [], { scalars: { AnyObject: 'timezone' } });
+    const result = await plugin(testSchema, [], { scalars: { AnyObject: 'rgb_array' } });
 
     expect(result).toBeDefined();
-    expect(result).toContain('America/Maceio');
+    expect(result).toContain(JSON.stringify([41, 98, 185]));
     expect(result).toMatchSnapshot();
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -168,3 +168,12 @@ it('should generate mock data with as-is types and enums if typenames is "keep"'
     expect(result).not.toMatch(/ABC(TYPE|STATUS)/);
     expect(result).toMatchSnapshot();
 });
+
+it('should generate the `casual` data for a particular scalar mapping', async () => {
+    const result = await plugin(testSchema, [], { scalars: { AnyObject: 'email' } });
+
+    const emailRegex = /(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
+    expect(result).toBeDefined();
+    expect(emailRegex.test(result as string)).toBeTruthy();
+    expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
## Background

Some apps use custom scalar for date-related stuff. This caused issues with the way `graphql-codegen-typescript-mock-data` handles autogenerated data, since a "random string" (the current  default), may not always be what you need.

This PR allows you to define mapping from your custom scalars to a casual embedded generator, allowing you to specify exactly how your scalar's autogenerated value will be populated

Closes #20 

## Caveats
To make configuration simple, a few "shortcuts" were taken. Namely:

- the mapping only accepts a `casual` key (function or string) as a valid autogenerated value in order to align with the rest of the library
- if a function is passed, then it will be called with its default arguments, since providing custom parameters for a function through a YAML file, would complicate things more than normal