### PR TITLE
build: add autobuilding on npm installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     },
     "sideEffects": false,
     "scripts": {
+        "prepare": "npm run build",
+
         "build": "tsc -m esnext --outDir dist/esnext && tsc -m commonjs --outDir dist/commonjs",
         "test": "jest",
         "lint": "eslint 'src/**/*.{js,ts,tsx}' --quiet --fix && tsc --noEmit",


### PR DESCRIPTION
Make sure that `npm run build` runs when `npm install <package>`  is called