### PR TITLE
feat: allow users to specify the `prefix` of mock builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Defines the file path containing all GraphQL types. This file can also be genera
 
 Adds `__typename` property to mock data
 
+### prefix (`string`, defaultValue: `a` for constants & `an` for vowels)
+
+The prefix to add to the mock function name. Cannot be empty since it will clash with the associated
+typescript definition from `@graphql-codegen/typescript`
+
 ### enumValues (`string`, defaultValue: `pascal-case#pascalCase`)
 
 Changes the case of the enums. Accepts `upper-case#upperCase`, `pascal-case#pascalCase` or `keep`

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should add custom prefix if the \`prefix\` config option is specified 1`] = `
+"
+export const mockAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const mockAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const mockUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
+    };
+};
+
+export const mockUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+    };
+};
+"
+`;
+
 exports[`should generate mock data functions 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -168,3 +168,12 @@ it('should generate mock data with as-is types and enums if typenames is "keep"'
     expect(result).not.toMatch(/ABC(TYPE|STATUS)/);
     expect(result).toMatchSnapshot();
 });
+
+it('should add custom prefix if the `prefix` config option is specified', async () => {
+    const result = await plugin(testSchema, [], { prefix: 'mock' });
+
+    expect(result).toBeDefined();
+    expect(result).toMatch(/const mockUser/);
+    expect(result).not.toMatch(/const aUser/);
+    expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
This PR simply provides an option for users to specify the prefix that their mock builders will have.

Closes #22

Additional Context
Initially I tried to implement the addPrefix option, but I saw that when omitting the prefix, the generator function names collided with the name of the existing TS types from @graphql-codegen/typescript. That's why a prefix must always be present.

This PR makes sure t