### PR TITLE
Add config for prefixing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ Setting the typesPrefix to `Api.` will create the following mock data
 export const aUser = (overrides?: Partial<Api.User>): Api.User => {
 ```
 
-Allows you to define mappings for your custom scalars. Allows you to map any GraphQL Scalar to a
-[casual](https://github.com/boo1ean/casual#embedded-generators) embedded generator (string or
-function key)
-
 ## Example of usage
 
 **codegen.yml**

--- a/README.md
+++ b/README.md
@@ -37,6 +37,29 @@ Allows you to define mappings for your custom scalars. Allows you to map any Gra
 [casual](https://github.com/boo1ean/casual#embedded-generators) embedded generator (string or
 function key)
 
+### typesPrefix (`string`, defaultValue: '')
+
+Useful if you have globally exported types under a certain namespace.
+e.g If the types file is something like this
+
+```
+declare namespace Api {
+ type User {
+  ...
+ }
+}
+```
+
+Setting the typesPrefix to `Api.` will create the following mock data
+
+```
+export const aUser = (overrides?: Partial<Api.User>): Api.User => {
+```
+
+Allows you to define mappings for your custom scalars. Allows you to map any GraphQL Scalar to a
+[casual](https://github.com/boo1ean/casual#embedded-generators) embedded generator (string or
+function key)
+
 ## Example of usage
 
 **codegen.yml**

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,11 +192,16 @@ const getMockString = (
     typenamesConvention: NamingConvention,
     addTypename = false,
     prefix,
+    typesPrefix = '',
 ) => {
     const casedName = createNameConverter(typenamesConvention)(typeName);
     const typename = addTypename ? `\n        __typename: '${casedName}',` : '';
     return `
-export const ${toMockName(typeName, casedName, prefix)} = (overrides?: Partial<${casedName}>): ${casedName} => {
+export const ${toMockName(
+        typeName,
+        casedName,
+        prefix,
+    )} = (overrides?: Partial<${typesPrefix}${casedName}>): ${typesPrefix}${casedName} => {
     return {${typename}
 ${fields}
     };
@@ -212,6 +217,7 @@ export interface TypescriptMocksPluginConfig {
     addTypename?: boolean;
     prefix?: string;
     scalars?: ScalarMap;
+    typesPrefix?: string;
 }
 
 interface TypeItem {
@@ -301,7 +307,14 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                               .join('\n')
                         : '';
 
-                    return getMockString(fieldName, mockFields, typenamesConvention, false, config.prefix);
+                    return getMockString(
+                        fieldName,
+                        mockFields,
+                        typenamesConvention,
+                        false,
+                        config.prefix,
+                        config.typesPrefix,
+                    );
                 },
             };
         },
@@ -325,6 +338,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                         typenamesConvention,
                         !!config.addTypename,
                         config.prefix,
+                        config.typesPrefix,
                     );
                 },
             };

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -37,6 +37,43 @@ export const mockUser = (overrides?: Partial<User>): User => {
 "
 `;
 
+exports[`should add typesPrefix to all types when option is specified 1`] = `
+"
+export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<Api.User>): Api.User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+    };
+};
+"
+`;
+
 exports[`should correctly generate the \`casual\` data for a non-string scalar mapping 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
@@ -106,43 +143,6 @@ export const aUser = (overrides?: Partial<User>): User => {
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io',
-    };
-};
-"
-`;
-
-exports[`should correctly generate the add the typesPrefix to all types when option is specified 1`] = `
-"
-export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
-    };
-};
-
-export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
-    };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-    };
-};
-
-export const aUser = (overrides?: Partial<Api.User>): Api.User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
     };
 };
 "

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -111,6 +111,43 @@ export const aUser = (overrides?: Partial<User>): User => {
 "
 `;
 
+exports[`should correctly generate the add the typesPrefix to all types when option is specified 1`] = `
+"
+export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<Api.User>): Api.User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+    };
+};
+"
+`;
+
 exports[`should generate mock data functions 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -193,3 +193,12 @@ it('should correctly generate the `casual` data for a non-string scalar mapping'
     expect(result).toContain(JSON.stringify([41, 98, 185]));
     expect(result).toMatchSnapshot();
 });
+
+it('should add typesPrefix to all types when option is specified', async () => {
+    const result = await plugin(testSchema, [], { typesPrefix: 'Api.' });
+
+    expect(result).toBeDefined();
+    expect(result).toMatch(/: Api.User/);
+    expect(result).not.toMatch(/: User/);
+    expect(result).toMatchSnapshot();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.25.0.tgz#1147225d4763282a98abf4cbbc0e324eee4b038d"
   integrity sha512-XUgJir4roCPdUUX/5wo26dyj1eFZbYKIjP1SuVJDskZ4x3HOwhggBK5WBKkJFv5rGrWnAtVfZpOju4Qzez7GgQ==
 
-"@auto-it/bot-list@^9.46.0":
-  version "9.46.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.46.0.tgz#eef1fe0ae08673816efd3470a284c9ce7c4249c5"
-  integrity sha512-8qoTX5T2KCnpMzPSz9lkASmWhVI0V49UcqY8TW9mhQCnwApDi9Uy4OZ9gSApf8I/+FR3aNwmRPiZjkvLXy7Avw==
+"@auto-it/bot-list@^9.49.4":
+  version "9.49.4"
+  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-9.49.4.tgz#bc936cfb7bfac4361a3f57f3be71b0dca8d0239f"
+  integrity sha512-/XqOWNtHZFRou/qrpT56y9uVzgr4YiXGaFExNRbldS0ID0sk0bbDS3QxR09jYu71UGmPrJfpyEtlWf5jP5xyYA==
 
 "@auto-it/conventional-commits@^9.25.0":
   version "9.25.0"
@@ -61,12 +61,12 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/core@^9.46.0":
-  version "9.46.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.46.0.tgz#2ef366011e17e04fe424d49e0bafe6a9da3261a0"
-  integrity sha512-bEhFLHjilCXOlQ9zmrqZ2h+ZBgr2GKbBMViLRb2TQhDeWXOjAHJPcGKk1w9rPRDzfOkoXPKBahKQdljqzGErXA==
+"@auto-it/core@^9.49.4":
+  version "9.49.4"
+  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.49.4.tgz#2244c28f259a6a1ea2ba35214bd3f068647d17f8"
+  integrity sha512-fsKL3a0p8meWZlzLao2g6GWA1RWRlkofhsS1ffAgixEgD0jNeFCgm9DFDkOzpklbParCz35D/IzldYbgHjI5Bg==
   dependencies:
-    "@auto-it/bot-list" "^9.46.0"
+    "@auto-it/bot-list" "^9.49.4"
     "@octokit/graphql" "^4.4.0"
     "@octokit/plugin-enterprise-compatibility" "^1.2.2"
     "@octokit/plugin-retry" "^3.0.1"
@@ -93,6 +93,7 @@
     node-fetch "2.6.0"
     parse-author "^2.0.0"
     parse-github-url "1.0.2"
+    pretty-ms "^7.0.0"
     semver "^7.0.0"
     signale "^1.4.0"
     tapable "^2.0.0-beta.2"
@@ -102,12 +103,12 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/npm@^9.46.0":
-  version "9.46.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.46.0.tgz#aa2b191e12e4caae363563343b29e2d1363fb977"
-  integrity sha512-8YvVDOlRLr+rff9YNb/6aJ6wGjd152mnB1icUSG/FZyf5LsdKIAGm1R2pK6M5MDDi6xD8XVT/dL5P4tLwbQJUw==
+"@auto-it/npm@^9.49.4":
+  version "9.49.4"
+  resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-9.49.4.tgz#55e9498bfb660653e084b74c11998aec8c071de9"
+  integrity sha512-25xGeRDoSMATYJv3EJxLCHpdYCVN8BMnAha20WNSultlt5yCU1ZBHp6zK+UUX+eB0ch8Q7UNh9J0pG08fm1X1g==
   dependencies:
-    "@auto-it/core" "^9.46.0"
+    "@auto-it/core" "^9.49.4"
     await-to-js "^2.1.1"
     env-ci "^5.0.1"
     fp-ts "^2.5.3"
@@ -122,12 +123,12 @@
     url-join "^4.0.0"
     user-home "^2.0.0"
 
-"@auto-it/released@^9.46.0":
-  version "9.46.0"
-  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.46.0.tgz#2088a797b280528d2289133f1c5bbdc032f69b14"
-  integrity sha512-sQp+G/TR92xNWo4ILfD6CRVOA4uF1MjbqPTdTTFTlkDUlNZgG6fi3CbfxT0ugp5nrg+lAKLwAhoYxex8wx3daA==
+"@auto-it/released@^9.49.4":
+  version "9.49.4"
+  resolved "https://registry.yarnpkg.com/@auto-it/released/-/released-9.49.4.tgz#267cb6e4b449cc9107a21102f20ee4ceb1c59165"
+  integrity sha512-tQ8N8MCreJC033FZwnJDE4SIKJrv8/toTVKbrkfjqNnq7xuCsYPRpP6R+HzqEhWpmN48A0alycMfwD9OHVSV3Q==
   dependencies:
-    "@auto-it/core" "^9.46.0"
+    "@auto-it/core" "^9.49.4"
     deepmerge "^4.0.0"
     fp-ts "^2.5.3"
     io-ts "^2.1.2"
@@ -1443,14 +1444,14 @@ author-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
   integrity sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=
 
-auto@^9.46.0:
-  version "9.46.0"
-  resolved "https://registry.yarnpkg.com/auto/-/auto-9.46.0.tgz#6018864d74b9e6dcb5c37e6a31cae0d1d7d909b2"
-  integrity sha512-LnTbvRBZA0IxqBYVShtxgxAFWq9oVCq+h2PLYjZtpOXBJn+5LNMxNjEOv918efacRWgVE/KAaAauuIhWQagsqw==
+auto@^9.47.0:
+  version "9.49.4"
+  resolved "https://registry.yarnpkg.com/auto/-/auto-9.49.4.tgz#00c420289593769cca2518878bdf304ff97bd9b0"
+  integrity sha512-mnoYllKK28cQNhUFn0nlHpa0DYarOxBqmhtocI1hkIojIHy32M+7mINV5ELKKhbJ9ZEbXQPLgOW8inUAGiQtXg==
   dependencies:
-    "@auto-it/core" "^9.46.0"
-    "@auto-it/npm" "^9.46.0"
-    "@auto-it/released" "^9.46.0"
+    "@auto-it/core" "^9.49.4"
+    "@auto-it/npm" "^9.49.4"
+    "@auto-it/released" "^9.49.4"
     await-to-js "^2.1.1"
     chalk "^4.0.0"
     command-line-application "^0.10.1"
@@ -4804,6 +4805,11 @@ parse-json@^5.0.0:
     json-parse-better-errors "^1.0.1"
     lines-and-columns "^1.1.6"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
@@ -4978,6 +4984,13 @@ pretty-format@^25.1.0, pretty-format@^25.2.6:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
+
+pretty-ms@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.0.tgz#45781273110caf35f55cab21a8a9bd403a233dc0"
+  integrity sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==
+  dependencies:
+    parse-ms "^2.1.0"
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
Related with: https://github.com/ardeois/graphql-codegen-typescript-mock-data/issues/28

Allows adding a prefix to the generated types, useful when your types are globally exported (i.e when using the generator add plugin) so you don't need to import them into your files and can call them directly.

@ardeois let me know if implementation looks ok, I can add a couple more tests and then update the README 