### PR TITLE
Add terminateCircularRelationships option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# generated test file
+/tests/circular-mocks/mocks.ts
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
     transform: {
         '^.+\\.tsx?$': 'ts-jest',
     },
+    globalSetup: './tests/circular-mocks/create-mocks.ts',
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "graphql-codegen-typescript-mock-data",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "description": "GraphQL Codegen plugin for building mock data",
     "main": "dist/commonjs/index.js",
     "module": "dist/esnext/index.js",

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -670,3 +670,44 @@ export const aUSER = (overrides?: Partial<USER>): USER => {
 };
 "
 `;
+
+exports[`should use relationshipsToOmit argument to terminate circular relationships with terminateCircularRelationships enabled 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>, relationshipsToOmit: Set<string> = new Set()): AbcType => {
+    relationshipsToOmit.add('AbcType');
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>, relationshipsToOmit: Set<string> = new Set()): Avatar => {
+    relationshipsToOmit.add('Avatar');
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, relationshipsToOmit: Set<string> = new Set()): UpdateUserInput => {
+    relationshipsToOmit.add('UpdateUserInput');
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>, relationshipsToOmit: Set<string> = new Set()): User => {
+    relationshipsToOmit.add('User');
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+    };
+};
+"
+`;

--- a/tests/circular-mocks/create-mocks.ts
+++ b/tests/circular-mocks/create-mocks.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import { buildSchema } from 'graphql';
+import { plugin } from '../../src';
+export default async () => {
+    const circularSchema = buildSchema(/* GraphQL */ `
+        type A {
+            B: B!
+            C: C!
+        }
+        type B {
+            A: A!
+        }
+        type C {
+            aCollection: [A!]!
+        }
+    `);
+
+    const output = await plugin(circularSchema, [], { typesFile: './types.ts', terminateCircularRelationships: true });
+
+    fs.writeFileSync('./tests/circular-mocks/mocks.ts', output.toString());
+};

--- a/tests/circular-mocks/spec.ts
+++ b/tests/circular-mocks/spec.ts
@@ -1,0 +1,12 @@
+import { aB, aC, anA } from './mocks';
+
+it('should terminate circular relationships when terminateCircularRelationships is true', () => {
+    const a = anA();
+    expect(a).toEqual({ B: { A: {} }, C: { aCollection: [{}] } });
+
+    const b = aB();
+    expect(b).toEqual({ A: { B: {}, C: { aCollection: [{}] } } });
+
+    const c = aC();
+    expect(c).toEqual({ aCollection: [{ B: { A: {} }, C: {} }] });
+});

--- a/tests/circular-mocks/types.ts
+++ b/tests/circular-mocks/types.ts
@@ -1,0 +1,12 @@
+export type A = {
+    B: B;
+    C: C;
+};
+
+export type B = {
+    A: A;
+};
+
+export type C = {
+    aCollection: A[];
+};

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -232,3 +232,13 @@ it('should add typesPrefix to all types when option is specified', async () => {
     expect(result).not.toMatch(/: User/);
     expect(result).toMatchSnapshot();
 });
+
+it('should use relationshipsToOmit argument to terminate circular relationships with terminateCircularRelationships enabled', async () => {
+    const result = await plugin(testSchema, [], { terminateCircularRelationships: true });
+
+    expect(result).toBeDefined();
+    expect(result).toMatch(/relationshipsToOmit.add\('User'\)/);
+    expect(result).toMatch(/relationshipsToOmit.has\('Avatar'\) \? {} as Avatar : anAvatar\({}, relationshipsToOmit\)/);
+    expect(result).not.toMatch(/: anAvatar\(\)/);
+    expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
I ran into https://github.com/ardeois/graphql-codegen-typescript-mock-data/issues/13 when trying to bring in this plugin.

This introduces an option, terminateCircularRelationships, that when enabled, allows a particular type to only be resolved once by the mocks in a particular call stack. After the first time, subsequent resolutions will return an empty object.

This does not affect overrides, so if you need a circular structure, it can still be achieved using overrides. 

Testing was a little tricky, because this issue doesn't present itself until you actually call one of the generated mock functions.
What I've done is created a script (tests/circular-mocks/create-mocks.ts) that generates a set of mock functions for a schema with circular relationships. I hooked it up as a jest global set up script, so it will run before any test runs.

Then added a new test that imports the generated file and runs the mock functions (tests/circular-mocks/spec.ts)

I also pulled the code into our codebase, turned on the option, and it resolved the infinite recursion.