### PR TITLE
fix: add __typename to return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,7 @@ const getMockString = (
 ) => {
     const casedName = createNameConverter(typenamesConvention)(typeName);
     const typename = addTypename ? `\n        __typename: '${casedName}',` : '';
+    const typenameReturnType = addTypename ? `{ __typename: '${casedName}' } & ` : '';
 
     if (terminateCircularRelationships) {
         return `
@@ -236,7 +237,7 @@ export const ${toMockName(
             typeName,
             casedName,
             prefix,
-        )} = (overrides?: Partial<${typesPrefix}${casedName}>, relationshipsToOmit: Set<string> = new Set()): ${typesPrefix}${casedName} => {
+        )} = (overrides?: Partial<${typesPrefix}${casedName}>, relationshipsToOmit: Set<string> = new Set()): ${typenameReturnType}${typesPrefix}${casedName} => {
     relationshipsToOmit.add('${casedName}');
     return {${typename}
 ${fields}
@@ -248,7 +249,7 @@ export const ${toMockName(
             typeName,
             casedName,
             prefix,
-        )} = (overrides?: Partial<${typesPrefix}${casedName}>): ${typesPrefix}${casedName} => {
+        )} = (overrides?: Partial<${typesPrefix}${casedName}>): ${typenameReturnType}${typesPrefix}${casedName} => {
     return {${typename}
 ${fields}
     };

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -559,14 +559,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data with typename if addTypename is true 1`] = `
 "
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>): { __typename: 'AbcType' } & AbcType => {
     return {
         __typename: 'AbcType',
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
     };
 };
 
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+export const anAvatar = (overrides?: Partial<Avatar>): { __typename: 'Avatar' } & Avatar => {
     return {
         __typename: 'Avatar',
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
@@ -582,7 +582,7 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
     };
 };
 
-export const aUser = (overrides?: Partial<User>): User => {
+export const aUser = (overrides?: Partial<User>): { __typename: 'User' } & User => {
     return {
         __typename: 'User',
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',


### PR DESCRIPTION
When `addTypename` is `true`, we should also add the property `__typename` in the return type