### PR TITLE
Added support for custom generator function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@
 #
 # Check {{ '/2.0/language-javascript/' | docs_url }} for more details
 #
+
 defaults: &defaults
   working_directory: ~/repo
   docker:

--- a/README.md
+++ b/README.md
@@ -82,9 +82,6 @@ plugins:
 plugins:
   - add: "import { arrayBufferGenerator } from '../generators';"
   - typescript-mock-data:
-      typesFile: '../generated-types.ts'
-      enumValues: upper-case#upperCase
-      typenames: keep
       scalars:
         ArrayBuffer: arrayBufferGenerator()
 ```

--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ generates:
             AWSTimestamp: unix_time # gets translated to casual.unix_time
 ```
 
+## Scalar custom value generator
+
+**codegen.yml**
+
+```yaml
+overwrite: true
+schema: schema.graphql
+generates:
+  src/generated-types.ts:
+    plugins:
+      - 'typescript'
+  src/mocks/generated-mocks.ts:
+    plugins:
+      - add: "import { arrayBufferGenerator } from '../generators';"
+      - typescript-mock-data:
+          typesFile: '../generated-types.ts'
+          enumValues: upper-case#upperCase
+          typenames: keep
+          scalars:
+            ArrayBuffer: arrayBufferGenerator()
+```
+
 ## Example or generated code
 
 Given the following schema:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ plugins:
         Date: date # gets translated to casual.date()
 ```
 
-**Scalar custom value generator**
+**Custom value generator**
 
 ```yaml
 plugins:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ plugins:
         Date: date # gets translated to casual.date()
 ```
 
+**Scalar custom value generator**
+
+```yaml
+plugins:
+  - add: "import { arrayBufferGenerator } from '../generators';"
+  - typescript-mock-data:
+      typesFile: '../generated-types.ts'
+      enumValues: upper-case#upperCase
+      typenames: keep
+      scalars:
+        ArrayBuffer: arrayBufferGenerator()
+```
+
 ### typesPrefix (`string`, defaultValue: '')
 
 Useful if you have globally exported types under a certain namespace.
@@ -114,28 +127,6 @@ generates:
           typenames: keep
           scalars:
             AWSTimestamp: unix_time # gets translated to casual.unix_time
-```
-
-## Scalar custom value generator
-
-**codegen.yml**
-
-```yaml
-overwrite: true
-schema: schema.graphql
-generates:
-  src/generated-types.ts:
-    plugins:
-      - 'typescript'
-  src/mocks/generated-mocks.ts:
-    plugins:
-      - add: "import { arrayBufferGenerator } from '../generators';"
-      - typescript-mock-data:
-          typesFile: '../generated-types.ts'
-          enumValues: upper-case#upperCase
-          typenames: keep
-          scalars:
-            ArrayBuffer: arrayBufferGenerator()
 ```
 
 ## Example or generated code

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,11 @@ const getNamedType = (
                         // If there is a mapping to a `casual` type, then use it and make sure
                         // to call it if it's a function
                         const embeddedGenerator = casual[customScalar.generator];
+
+                        if (!embeddedGenerator && customScalar.generator) {
+                            return customScalar.generator;
+                        }
+
                         const generatorArgs: unknown[] = Array.isArray(customScalar.arguments)
                             ? customScalar.arguments
                             : [customScalar.arguments];
@@ -257,7 +262,7 @@ ${fields}
     }
 };
 
-type ScalarGeneratorName = keyof Casual.Casual | keyof Casual.functions;
+type ScalarGeneratorName = keyof Casual.Casual | keyof Casual.functions | string;
 type ScalarDefinition = {
     generator: ScalarGeneratorName;
     arguments: unknown;

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -222,6 +222,43 @@ export const aUser = (overrides?: Partial<User>): User => {
 "
 `;
 
+exports[`should correctly generate the default custom value of scalar 1`] = `
+"
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : myValueGenerator(),
+    };
+};
+"
+`;
+
 exports[`should generate mock data functions 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -222,7 +222,7 @@ export const aUser = (overrides?: Partial<User>): User => {
 "
 `;
 
-exports[`should correctly generate the default custom value of scalar 1`] = `
+exports[`should correctly use custom generator as default value 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -224,6 +224,21 @@ it('should correctly generate the `casual` data for a function with one argument
     expect(result).toMatchSnapshot();
 });
 
+it('should correctly use custom generator as default value', async () => {
+    const result = await plugin(testSchema, [], {
+        scalars: {
+            AnyObject: {
+                generator: 'myValueGenerator()',
+                arguments: [],
+            },
+        },
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toContain('myValueGenerator()');
+    expect(result).toMatchSnapshot();
+});
+
 it('should add typesPrefix to all types when option is specified', async () => {
     const result = await plugin(testSchema, [], { typesPrefix: 'Api.' });
 


### PR DESCRIPTION
Hi, 

I need to generate a specific value for mock. This implementation enables me to use my custom value generator. eg.

config:

```yml
src/test/factory/graphql.ts:
   plugins:
       - add: "import { generateArrayBuffer } from '../generators';"
       - typescript-mock-data:
              typesFile: "../../shared/graphql/generated.ts"
              enumValues: upper-case#upperCase
              typenames: keep
              addTypename: true
              scalars:
                 ArrayBuffer:  generateArrayBuffer()
```

src/test/factory/graphql.ts
```ts
import { generateArrayBuffer } from '../generators;

export const anPakeProtocol = (overrides?: Partial<PakeProtocol>): PakeProtocol => {
    return {
        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
        message: overrides && overrides.hasOwnProperty('message') ? overrides.message! : generateArrayBuffer(),
    };
};
```