### PR TITLE
fix: update type case in `import`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -424,10 +424,11 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
     const result: any = visit(astNode, { leave: visitor });
     const definitions = result.definitions.filter((definition: any) => !!definition);
     const typesFile = config.typesFile ? config.typesFile.replace(/\.[\w]+$/, '') : null;
+    const typenameConverter = createNameConverter(typenamesConvention);
     const typeImports = definitions
-        .map(({ typeName }: { typeName: string }) => typeName)
+        .map(({ typeName }: { typeName: string }) => typenameConverter(typeName))
         .filter((typeName: string) => !!typeName);
-    typeImports.push(...types.filter(({ type }) => type !== 'scalar').map(({ name }) => name));
+    typeImports.push(...types.filter(({ type }) => type !== 'scalar').map(({ name }) => typenameConverter(name)));
     // List of function that will generate the mock.
     // We generate it after having visited because we need to distinct types from enums
     const mockFns = definitions.map(({ mockFn }: any) => mockFn).filter((mockFn: Function) => !!mockFn);

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -298,7 +298,7 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 exports[`should generate mock data functions with external types file import 1`] = `
 "/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
-import { ABCType, Avatar, UpdateUserInput, User, ABCStatus, Status } from './types/graphql';
+import { AbcType, Avatar, UpdateUserInput, User, AbcStatus, Status } from './types/graphql';
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
@@ -558,7 +558,9 @@ export const aUser = (overrides?: Partial<User>): User => {
 `;
 
 exports[`should generate mock data with pascalCase types and enums by default 1`] = `
-"
+"/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
+import { AbcType, Avatar, UpdateUserInput, User, AbcStatus, Status } from './types/graphql';
+
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -76,7 +76,7 @@ it('should generate mock data functions with external types file import', async 
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { ABCType, Avatar, UpdateUserInput, User, ABCStatus, Status } from './types/graphql';",
+        "import { AbcType, Avatar, UpdateUserInput, User, AbcStatus, Status } from './types/graphql';",
     );
     expect(result).toMatchSnapshot();
 });
@@ -130,7 +130,7 @@ it('should generate mock data with as-is enum values if enumValues is "keep"', a
 });
 
 it('should generate mock data with pascalCase types and enums by default', async () => {
-    const result = await plugin(testSchema, [], {});
+    const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts' });
 
     expect(result).toBeDefined();
     expect(result).toMatch(/Abc(Type|Status)/);


### PR DESCRIPTION
Some types were inconsistent when we had a type like `ABCType`.
The code was using `AbcType` but we were importing `ABCType`