### PR TITLE
fix: update graphql peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "upper-case": "^2.0.1"
     },
     "peerDependencies": {
-        "graphql": "^14.6.0"
+        "graphql": "^14.6.0 || ^15.0.0"
     },
     "devDependencies": {
         "@auto-it/conventional-commits": "^9.57.0",


### PR DESCRIPTION
Bump graphql dependency to allow 15.x