### PR TITLE
fix(typesPrefix): use typesPrefix in imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ declare namespace Api {
 }
 ```
 
-Setting the typesPrefix to `Api.` will create the following mock data
+Setting the `typesPrefix` to `Api.` will create the following mock data
 
 ```
 export const aUser = (overrides?: Partial<Api.User>): Api.User => {

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -102,6 +102,59 @@ export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar
 "
 `;
 
+exports[`should add typesPrefix to imports 1`] = `
+"/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
+import { Api.AbcType, Api.Avatar, Api.CamelCaseThing, Api.UpdateUserInput, Api.User, Api.WithAvatar, AbcStatus, Status } from './types/graphql';
+
+export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aUser = (overrides?: Partial<Api.User>): Api.User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
+    };
+};
+
+export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+"
+`;
+
 exports[`should correctly generate the \`casual\` data for a function with arguments scalar mapping 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -978,6 +978,59 @@ export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>): WITHAVATAR => {
 "
 `;
 
+exports[`should generate mock data with upperCase types and imports if typenames is "upper-case#upperCase" 1`] = `
+"/* eslint-disable @typescript-eslint/no-use-before-define,@typescript-eslint/no-unused-vars,no-prototype-builtins */
+import { ABCTYPE, AVATAR, CAMELCASETHING, UPDATEUSERINPUT, USER, WITHAVATAR, ABCSTATUS, STATUS } from './types/graphql';
+
+export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>): CAMELCASETHING => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+    };
+};
+
+export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>): UPDATEUSERINPUT => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+    };
+};
+
+export const aUSER = (overrides?: Partial<USER>): USER => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING(),
+    };
+};
+
+export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>): WITHAVATAR => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+    };
+};
+"
+`;
+
 exports[`should use relationshipsToOmit argument to terminate circular relationships with terminateCircularRelationships enabled 1`] = `
 "
 export const anAbcType = (overrides?: Partial<AbcType>, relationshipsToOmit: Set<string> = new Set()): AbcType => {

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -177,6 +177,16 @@ it('should generate mock data with upperCase types and enums if typenames is "up
     expect(result).toMatchSnapshot();
 });
 
+it('should generate mock data with upperCase types and imports if typenames is "upper-case#upperCase"', async () => {
+    const result = await plugin(testSchema, [], { typenames: 'upper-case#upperCase', typesFile: './types/graphql.ts' });
+
+    expect(result).toBeDefined();
+    expect(result).not.toMatch(/Abc(Type|Status)/);
+    expect(result).not.toMatch(/ABC(Type|Status)/);
+    expect(result).toMatch(/ABC(TYPE|STATUS)/);
+    expect(result).toMatchSnapshot();
+});
+
 it('should generate mock data with as-is types and enums if typenames is "keep"', async () => {
     const result = await plugin(testSchema, [], { typenames: 'keep' });
 

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -276,6 +276,16 @@ it('should add typesPrefix to all types when option is specified', async () => {
     expect(result).toMatchSnapshot();
 });
 
+it('should add typesPrefix to imports', async () => {
+    const result = await plugin(testSchema, [], { typesPrefix: 'Api.', typesFile: './types/graphql.ts' });
+
+    expect(result).toBeDefined();
+    expect(result).toContain(
+        "import { Api.AbcType, Api.Avatar, Api.CamelCaseThing, Api.UpdateUserInput, Api.User, Api.WithAvatar, AbcStatus, Status } from './types/graphql';",
+    );
+    expect(result).toMatchSnapshot();
+});
+
 it('should use relationshipsToOmit argument to terminate circular relationships with terminateCircularRelationships enabled', async () => {
     const result = await plugin(testSchema, [], { terminateCircularRelationships: true });
 


### PR DESCRIPTION
When option `typesFile` was used, the `import` line was not
using `typesPrefix` for types

Also used objects in function parameters, as the current params were getting out of control