### PR TITLE
fix: never preserve underscores for enum values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
                         return `${typenameConverter(foundType.name, opts.enumsPrefix)}.${updateTextCase(
                             value,
                             opts.enumValuesConvention,
-                            opts.transformUnderscore,
+                            true,
                         )}`;
                     }
                     case 'union':

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -20,6 +20,7 @@ export const mockUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : mockCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : mockAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -91,6 +92,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -163,6 +165,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -235,6 +238,7 @@ export const aUser = (overrides?: Partial<Api.User>): Api.User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -306,6 +310,7 @@ export const aUser = (overrides?: Partial<Api.User>): Api.User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -358,7 +363,7 @@ export const aQuery = (overrides?: Partial<Api.Query>): Api.Query => {
 `;
 
 exports[`should add typesPrefix to imports 1`] = `
-"import { Api, AbcStatus, Status } from './types/graphql';
+"import { Api, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
     return {
@@ -378,6 +383,7 @@ export const aUser = (overrides?: Partial<Api.User>): Api.User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -449,6 +455,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -520,6 +527,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -591,6 +599,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,98,185],
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -662,6 +671,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -733,6 +743,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : myValueGenerator(),
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -804,6 +815,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -856,7 +868,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should generate mock data functions with external types file import 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -876,6 +888,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -947,6 +960,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -1018,6 +1032,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -1089,6 +1104,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -1160,6 +1176,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -1212,7 +1229,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should generate mock data with PascalCase types and enums by default 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -1232,6 +1249,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -1303,6 +1321,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE,
     };
 };
 
@@ -1374,6 +1393,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : acamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,
     };
 };
 
@@ -1447,6 +1467,7 @@ export const aUser = (overrides?: Partial<User>): { __typename: 'User' } & User 
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -1524,6 +1545,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE,
     };
 };
 
@@ -1595,6 +1617,7 @@ export const aUSER = (overrides?: Partial<USER>): USER => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue,
     };
 };
 
@@ -1647,7 +1670,7 @@ export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
 `;
 
 exports[`should generate mock data with upperCase types and imports if typenames is "upper-case#upperCase" 1`] = `
-"import { AVATAR, USER, WITHAVATAR, CAMELCASETHING, PREFIXED_RESPONSE, ABCTYPE, UPDATEUSERINPUT, MUTATION, QUERY, ABCSTATUS, STATUS } from './types/graphql';
+"import { AVATAR, USER, WITHAVATAR, CAMELCASETHING, PREFIXED_RESPONSE, ABCTYPE, UPDATEUSERINPUT, MUTATION, QUERY, ABCSTATUS, STATUS, PREFIXED_ENUM } from './types/graphql';
 
 export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
     return {
@@ -1667,6 +1690,7 @@ export const aUSER = (overrides?: Partial<USER>): USER => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue,
     };
 };
 
@@ -1719,7 +1743,7 @@ export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
 `;
 
 exports[`should not merge imports into one if enumsPrefix does not contain dots 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, ApiAbcStatus, ApiStatus } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -1739,6 +1763,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : ApiPrefixedEnum.PrefixedValue,
     };
 };
 
@@ -1791,7 +1816,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should not merge imports into one if typesPrefix does not contain dots 1`] = `
-"import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiUpdateUserInput, ApiMutation, ApiQuery, AbcStatus, Status } from './types/graphql';
+"import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiUpdateUserInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<ApiAvatar>): ApiAvatar => {
     return {
@@ -1811,6 +1836,7 @@ export const aUser = (overrides?: Partial<ApiUser>): ApiUser => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
@@ -1863,7 +1889,7 @@ export const aQuery = (overrides?: Partial<ApiQuery>): ApiQuery => {
 `;
 
 exports[`should preserve underscores if transformUnderscore is false 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -1883,6 +1909,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,
     };
 };
 
@@ -1956,6 +1983,7 @@ export const aUser = (overrides?: Partial<User>, relationshipsToOmit: Set<string
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : relationshipsToOmit.has('CamelCaseThing') ? {} as CamelCaseThing : aCamelCaseThing({}, relationshipsToOmit),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -22,6 +22,7 @@ const testSchema = buildSchema(/* GraphQL */ `
         scalarValue: AnyObject!
         camelCaseThing: camelCaseThing
         unionThing: UnionThing
+        prefixedEnum: Prefixed_Enum
     }
 
     interface WithAvatar {
@@ -54,6 +55,10 @@ const testSchema = buildSchema(/* GraphQL */ `
     enum Status {
         ONLINE
         OFFLINE
+    }
+
+    enum Prefixed_Enum {
+        PREFIXED_VALUE
     }
 
     union UnionThing = Avatar | camelCaseThing
@@ -94,7 +99,7 @@ it('should generate mock data functions with external types file import', async 
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status } from './types/graphql';",
+        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';",
     );
     expect(result).toMatchSnapshot();
 });
@@ -289,7 +294,8 @@ it('should add typesPrefix to imports', async () => {
     const result = await plugin(testSchema, [], { typesPrefix: 'Api.', typesFile: './types/graphql.ts' });
 
     expect(result).toBeDefined();
-    expect(result).toContain("import { Api, AbcStatus, Status } from './types/graphql';");
+    expect(result).toContain("import { Api, AbcStatus, Status, PrefixedEnum } from './types/graphql';");
+
     expect(result).toMatchSnapshot();
 });
 
@@ -335,7 +341,7 @@ it('should not merge imports into one if typesPrefix does not contain dots', asy
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiUpdateUserInput, ApiMutation, ApiQuery, AbcStatus, Status } from './types/graphql';",
+        "import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiUpdateUserInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';",
     );
     expect(result).toMatchSnapshot();
 });
@@ -348,7 +354,7 @@ it('should not merge imports into one if enumsPrefix does not contain dots', asy
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, ApiAbcStatus, ApiStatus } from './types/graphql';",
+        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, UpdateUserInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';",
     );
     expect(result).toMatchSnapshot();
 });
@@ -371,10 +377,13 @@ it('should preserve underscores if transformUnderscore is false', async () => {
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status } from './types/graphql';",
+        "import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, UpdateUserInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';",
     );
     expect(result).toContain(
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
+    );
+    expect(result).toContain(
+        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,",
     );
     expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
A fix for https://github.com/ardeois/graphql-codegen-typescript-mock-data/pull/61

In `@graphql-codegen/typescript` enum values never preserve underscores, as a conscious decision: https://github.com/dotansimha/graphql-code-generator/issues/1569

This fix aligns with that decision.