### PR TITLE
fix: add tslib dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "indefinite": "^2.4.1",
         "pascal-case": "^3.1.1",
         "sentence-case": "^3.0.3",
+        "tslib": "^2.4.0",
         "upper-case": "^2.0.1"
     },
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5315,6 +5315,11 @@ tslib@^2, tslib@^2.0.3, tslib@^2.1.0, tslib@~2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@~2.0.0, tslib@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"


### PR DESCRIPTION
Add missing `tslib` dependency.

This dependency is necessary after rollup converted typescript to ES or commonjs