### PR TITLE
fix: listElementCount sometimes undefined

### DIFF
--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -51,7 +51,7 @@ export const mockAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const mockListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -129,7 +129,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -208,7 +208,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -287,7 +287,7 @@ export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
 
 export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -365,7 +365,7 @@ export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
 
 export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -444,7 +444,7 @@ export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
 
 export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -522,7 +522,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -600,7 +600,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -678,7 +678,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -756,7 +756,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -834,7 +834,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -995,7 +995,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1074,7 +1074,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1152,7 +1152,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1230,7 +1230,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1308,7 +1308,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1386,7 +1386,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1465,7 +1465,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1543,7 +1543,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1621,7 +1621,7 @@ export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1706,7 +1706,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): { __typename: 'ABCType'
 export const aListType = (overrides?: Partial<ListType>): { __typename: 'ListType' } & ListType => {
     return {
         __typename: 'ListType',
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1786,7 +1786,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1864,7 +1864,7 @@ export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
 
 export const aLISTTYPE = (overrides?: Partial<LISTTYPE>): LISTTYPE => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -1943,7 +1943,7 @@ export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
 
 export const aLISTTYPE = (overrides?: Partial<LISTTYPE>): LISTTYPE => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -2101,7 +2101,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -2180,7 +2180,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -2259,7 +2259,7 @@ export const anAbcType = (overrides?: Partial<ApiAbcType>): ApiAbcType => {
 
 export const aListType = (overrides?: Partial<ApiListType>): ApiListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -2338,7 +2338,7 @@ export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
@@ -2423,7 +2423,7 @@ export const anAbcType = (overrides?: Partial<AbcType>, _relationshipsToOmit: Ar
 export const aListType = (overrides?: Partial<ListType>, _relationshipsToOmit: Array<string> = []): ListType => {
     const relationshipsToOmit = ([..._relationshipsToOmit, 'ListType']);
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id'],
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -401,7 +401,7 @@ it('should generate single list element', async () => {
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id']",
+        "stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem']",
     );
     expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
Update the generator to make sure `listElementCount` is set to 1 when undefined The output was also different than before version `2.4.0` since `fieldName` changed when generating list items

This PR makes sure the output of generated files is the same as before if we don't touch `listElementCount` option