### PR TITLE
fix: custom generator for native scalars

### DIFF
--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should generate custom scalars for native and custom types 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Kelly_Cremin@Turcotte.biz',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
+"
+`;

--- a/tests/scalars/schema.ts
+++ b/tests/scalars/schema.ts
@@ -1,0 +1,18 @@
+import { buildSchema } from 'graphql';
+
+export default buildSchema(/* GraphQL */ `
+    scalar AnyObject
+
+    type A {
+        id: ID!
+        str: String!
+        obj: B!
+        anyObject: AnyObject!
+    }
+
+    type B {
+        int: Int!
+        flt: Float!
+        bool: Boolean!
+    }
+`);

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -1,0 +1,47 @@
+import { plugin } from '../../src';
+import testSchema from './schema';
+
+it('should generate custom scalars for native and custom types', async () => {
+    const result = await plugin(testSchema, [], {
+        scalars: {
+            String: 'string',
+            Float: {
+                generator: 'double',
+                arguments: [-100, 0],
+            },
+            ID: {
+                generator: 'integer',
+                arguments: [1, 100],
+            },
+            Boolean: 'false',
+            Int: {
+                generator: 'integer',
+                arguments: [-100, 0],
+            },
+            AnyObject: 'email',
+        },
+    });
+
+    expect(result).toBeDefined();
+
+    // String
+    expect(result).toContain(
+        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',",
+    );
+
+    // Float
+    expect(result).toContain(
+        "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,",
+    );
+
+    // ID
+    expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,");
+
+    // Boolean
+    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+
+    // Int
+    expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
+
+    expect(result).toMatchSnapshot();
+});

--- a/tests/scalars/types.ts
+++ b/tests/scalars/types.ts
@@ -1,0 +1,12 @@
+export type A = {
+    id: string;
+    str: string;
+    obj: B;
+    anyObject: any;
+};
+
+export type B = {
+    int: number;
+    flt: number;
+    bool: boolean;
+};


### PR DESCRIPTION
Only non-native scalars were supported by the `scalars` config. We now check if a custom scalar is defined for each native type

fixes #91 