### PR TITLE
feat: query document mocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -273,7 +273,7 @@ const getMockString = (
         casedName,
         prefix,
     )} = (${params}): ${typenameReturnType}${casedNameWithPrefix} => {
-        ${isQueryFunction ? 'const _selectionSet = queryDocument?.definitions[0].selectionSet;' : ''}
+        ${isQueryFunction ? 'const _selectionSet = queryDocument?.definitions[0]["selectionSet"];' : ''}
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         ${
             terminateCircularRelationships

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
         dynamicValues: opts.dynamicValues,
     });
     if (!opts.dynamicValues)
-        mockValueGenerator.seed(hashedString(`${opts.typeName}${opts.fieldName}${opts.index ? opts.index : ''}`));
+        mockValueGenerator.seed(hashedString(`${opts.typeName}${opts.fieldName}${opts.index ?? ''}`));
     const name = opts.currentType.name.value;
     const casedName = createNameConverter(opts.typenamesConvention, opts.transformUnderscore)(name);
     switch (name) {
@@ -236,7 +236,7 @@ const generateMockValue = (opts: Options): string | number | boolean => {
                 generateMockValue({
                     ...opts,
                     fieldName: opts.fieldName,
-                    index,
+                    ...(opts.listElementCount > 1 ? { index } : {}),
                     currentType: (opts.currentType as ListTypeNode).type,
                 }),
             );

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -70,7 +70,7 @@ export const mockMutation = (overrides?: Partial<Mutation>, _selectionSet?: Sele
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : mockUser({}, attributesSelectionSet?.updateUser),};
     };
 export const mockQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : mockUser({}, attributesSelectionSet?.user),
@@ -149,7 +149,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -229,7 +229,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -309,7 +309,7 @@ export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: Sel
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -388,7 +388,7 @@ export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: Sel
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -468,7 +468,7 @@ export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: Sel
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -547,7 +547,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -626,7 +626,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -705,7 +705,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -784,7 +784,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -863,7 +863,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -945,7 +945,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1029,7 +1029,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1110,7 +1110,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1189,7 +1189,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1269,7 +1269,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1348,7 +1348,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1427,7 +1427,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1506,7 +1506,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1585,7 +1585,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1664,7 +1664,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1744,7 +1744,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1823,7 +1823,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1902,7 +1902,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -1989,7 +1989,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         __typename: 'Mutation',        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): { __typename: 'Query' } & Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
@@ -2069,7 +2069,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -2148,7 +2148,7 @@ export const aMUTATION = (overrides?: Partial<MUTATION>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as USER : aUSER({}, attributesSelectionSet?.updateUser),};
     };
 export const aQUERY = (overrides?: Partial<QUERY>, queryDocument?: DocumentNode): QUERY => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as USER : aUSER({}, attributesSelectionSet?.user),
@@ -2228,7 +2228,7 @@ export const aMUTATION = (overrides?: Partial<MUTATION>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as USER : aUSER({}, attributesSelectionSet?.updateUser),};
     };
 export const aQUERY = (overrides?: Partial<QUERY>, queryDocument?: DocumentNode): QUERY => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as USER : aUSER({}, attributesSelectionSet?.user),
@@ -2308,7 +2308,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -2388,7 +2388,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -2468,7 +2468,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -2548,7 +2548,7 @@ export const aMutation = (overrides?: Partial<ApiMutation>, _selectionSet?: Sele
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<ApiQuery>, queryDocument?: DocumentNode): ApiQuery => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -2628,7 +2628,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: Selecti
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
@@ -2707,7 +2707,7 @@ export const aMutation = (overrides?: Partial<Mutation>, _relationshipsToOmit: A
         return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : relationshipsToOmit.includes('User') || attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, relationshipsToOmit, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, _relationshipsToOmit: Array<string> = [], queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const _selectionSet = queryDocument?.definitions[0][\\"selectionSet\\"];
         const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         const relationshipsToOmit = ([..._relationshipsToOmit, 'Query']);
         return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : relationshipsToOmit.includes('User') || attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, relationshipsToOmit, attributesSelectionSet?.user),

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1,863 +1,863 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should add custom prefix if the \`prefix\` config option is specified 1`] = `
-"
-export const mockAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const mockAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const mockUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : mockCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : mockAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const mockUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : mockCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : mockAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const mockWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
+export const mockWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const mockCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const mockCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const mockPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const mockPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const mockAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const mockAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const mockListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const mockListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const mockUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const mockUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const mockMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : mockUser(),
+export const mockMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : mockUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const mockQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : mockUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : mockPrefixedResponse(),
+export const mockQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : mockUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : mockPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should add enumsPrefix to all enums when option is specified 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should add enumsPrefix to imports 1`] = `
 "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, Api } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should add typesPrefix and enumsPrefix to imports 1`] = `
 "import { Api } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: DocumentNode): Api.Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<Api.User>): Api.User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: DocumentNode): Api.User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: DocumentNode): Api.WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: DocumentNode): Api.CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>): Api.PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: DocumentNode): Api.PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: DocumentNode): Api.AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: DocumentNode): Api.ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: DocumentNode): Api.UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Api.Mutation>): Api.Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: DocumentNode): Api.Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Api.Query>): Api.Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should add typesPrefix to all types when option is specified 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: DocumentNode): Api.Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<Api.User>): Api.User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: DocumentNode): Api.User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: DocumentNode): Api.WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: DocumentNode): Api.CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>): Api.PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: DocumentNode): Api.PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: DocumentNode): Api.AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: DocumentNode): Api.ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: DocumentNode): Api.UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Api.Mutation>): Api.Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: DocumentNode): Api.Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Api.Query>): Api.Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should add typesPrefix to imports 1`] = `
 "import { Api, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: DocumentNode): Api.Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<Api.User>): Api.User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: DocumentNode): Api.User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: DocumentNode): Api.WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: DocumentNode): Api.CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>): Api.PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: DocumentNode): Api.PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: DocumentNode): Api.AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: DocumentNode): Api.ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: DocumentNode): Api.UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Api.Mutation>): Api.Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: DocumentNode): Api.Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Api.Query>): Api.Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should correctly generate the \`casual\` data for a function with arguments scalar mapping 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should correctly generate the \`casual\` data for a function with one argument scalar mapping 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should correctly generate the \`casual\` data for a non-string scalar mapping 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,98,185],
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,98,185] }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should correctly generate the \`casual\` data for a scalar mapping of type string 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should correctly use custom generator as default value 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : myValueGenerator(),
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : myValueGenerator() }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
@@ -865,80 +865,80 @@ exports[`should generate dynamic values in mocks 1`] = `
 "import casual from 'casual';
 
 casual.seed(0);
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : casual.word,
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : casual.word }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : new Date(casual.unix_time).toISOString(),
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : new Date(casual.unix_time).toISOString() }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : casual.word }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : casual.word }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+    };
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+    };
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid }),};
+    };
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : casual.word }),};
+    };
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : casual.word }),};
+    };
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [casual.word] }),};
+    };
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : casual.word,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : casual.word,
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : casual.word,
-    };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : casual.word,
-    };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [casual.word],
-    };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : casual.word,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-    };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
-    };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
-    };
-};
 
 export const seedMocks = (seed: number) => casual.seed(seed);
 "
@@ -948,395 +948,395 @@ exports[`should generate dynamic values with faker 1`] = `
 "import { faker } from '@faker-js/faker';
 
 faker.seed(0);
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : faker.lorem.word(),
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid() }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : faker.lorem.word() }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : faker.date.past(1, new Date(2022, 0)).toISOString(),
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid() }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : faker.date.past(1, new Date(2022, 0)).toISOString() }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : faker.lorem.word() }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : faker.lorem.word() }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+    };
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid() }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+    };
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid() }),};
+    };
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : faker.lorem.word() }),};
+    };
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : faker.lorem.word() }),};
+    };
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [faker.lorem.word()] }),};
+    };
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : faker.lorem.word(),
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : faker.lorem.word(),
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : faker.lorem.word(),
-    };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : faker.lorem.word(),
-    };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [faker.lorem.word()],
-    };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : faker.lorem.word(),
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-    };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
-    };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
-    };
-};
 
 export const seedMocks = (seed: number) => faker.seed(seed);
 "
 `;
 
 exports[`should generate mock data functions 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data functions with casual 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data functions with external types file import 1`] = `
 "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data functions with faker 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-bc38-ef1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-bc38-ef1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-9a7d-c13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-9a7d-c13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-8230-d4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-8230-d4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-900f-beee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-900f-beee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-9e5f-14155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-9e5f-14155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'eos',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
@@ -1419,793 +1419,793 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should generate mock data with PascalCase enum values by default 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with PascalCase enum values if enumValues is "pascal-case#pascalCase" 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with PascalCase enum values if typenames is "pascal-case#pascalCase" 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with PascalCase types and enums by default 1`] = `
 "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with as-is enum values if enumValues is "keep" 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.hasXYZStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.hasXYZStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with as-is types and enums if typenames is "keep" 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : acamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : acamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const acamelCaseThing = (overrides?: Partial<camelCaseThing>): camelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const acamelCaseThing = (overrides?: Partial<camelCaseThing>, _selectionSet?: DocumentNode): camelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>, _selectionSet?: DocumentNode): Prefixed_Response => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anABCType = (overrides?: Partial<ABCType>, _selectionSet?: DocumentNode): ABCType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with typename if addTypename is true 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): { __typename: 'Avatar' } & Avatar => {
-    return {
-        __typename: 'Avatar',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): { __typename: 'Avatar' } & Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'Avatar',        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): { __typename: 'User' } & User => {
-    return {
-        __typename: 'User',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): { __typename: 'User' } & User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'User',        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): { __typename: 'WithAvatar' } & WithAvatar => {
-    return {
-        __typename: 'WithAvatar',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): { __typename: 'WithAvatar' } & WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'WithAvatar',        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): { __typename: 'camelCaseThing' } & CamelCaseThing => {
-    return {
-        __typename: 'camelCaseThing',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): { __typename: 'camelCaseThing' } & CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'camelCaseThing',        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): { __typename: 'Prefixed_Response' } & PrefixedResponse => {
-    return {
-        __typename: 'Prefixed_Response',
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): { __typename: 'Prefixed_Response' } & PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'Prefixed_Response',        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): { __typename: 'ABCType' } & AbcType => {
-    return {
-        __typename: 'ABCType',
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): { __typename: 'ABCType' } & AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'ABCType',        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): { __typename: 'ListType' } & ListType => {
-    return {
-        __typename: 'ListType',
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): { __typename: 'ListType' } & ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'ListType',        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): { __typename: 'Mutation' } & Mutation => {
-    return {
-        __typename: 'Mutation',
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): { __typename: 'Mutation' } & Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'Mutation',        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): { __typename: 'Query' } & Query => {
-    return {
-        __typename: 'Query',
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): { __typename: 'Query' } & Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'Query',        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with upperCase enum values if enumValues is "upper-case#upperCase" 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HASXYZSTATUS,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HASXYZSTATUS }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with upperCase types and enums if typenames is "upper-case#upperCase" 1`] = `
-"
-export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"export const anAVATAR = (overrides?: Partial<AVATAR>, _selectionSet?: DocumentNode): AVATAR => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUSER = (overrides?: Partial<USER>): USER => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue,
+export const aUSER = (overrides?: Partial<USER>, _selectionSet?: DocumentNode): USER => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue }),};
     };
-};
-
-export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>): WITHAVATAR => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>, _selectionSet?: DocumentNode): WITHAVATAR => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>): CAMELCASETHING => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>, _selectionSet?: DocumentNode): CAMELCASETHING => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>): PREFIXED_RESPONSE => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>, _selectionSet?: DocumentNode): PREFIXED_RESPONSE => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anABCTYPE = (overrides?: Partial<ABCTYPE>, _selectionSet?: DocumentNode): ABCTYPE => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aLISTTYPE = (overrides?: Partial<LISTTYPE>): LISTTYPE => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aLISTTYPE = (overrides?: Partial<LISTTYPE>, _selectionSet?: DocumentNode): LISTTYPE => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>): UPDATEUSERINPUT => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>, _selectionSet?: DocumentNode): UPDATEUSERINPUT => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMUTATION = (overrides?: Partial<MUTATION>): MUTATION => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER(),
+export const aMUTATION = (overrides?: Partial<MUTATION>, _selectionSet?: DocumentNode): MUTATION => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUSER(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPREFIXED_RESPONSE(),
+export const aQUERY = (overrides?: Partial<QUERY>, queryDocument?: DocumentNode): QUERY => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUSER({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPREFIXED_RESPONSE({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with upperCase types and imports if typenames is "upper-case#upperCase" 1`] = `
 "import { AVATAR, USER, WITHAVATAR, CAMELCASETHING, PREFIXED_RESPONSE, ABCTYPE, LISTTYPE, UPDATEUSERINPUT, MUTATION, QUERY, ABCSTATUS, STATUS, PREFIXED_ENUM } from './types/graphql';
-
-export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAVATAR = (overrides?: Partial<AVATAR>, _selectionSet?: DocumentNode): AVATAR => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUSER = (overrides?: Partial<USER>): USER => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue,
+export const aUSER = (overrides?: Partial<USER>, _selectionSet?: DocumentNode): USER => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue }),};
     };
-};
-
-export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>): WITHAVATAR => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>, _selectionSet?: DocumentNode): WITHAVATAR => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>): CAMELCASETHING => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>, _selectionSet?: DocumentNode): CAMELCASETHING => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>): PREFIXED_RESPONSE => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>, _selectionSet?: DocumentNode): PREFIXED_RESPONSE => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anABCTYPE = (overrides?: Partial<ABCTYPE>, _selectionSet?: DocumentNode): ABCTYPE => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aLISTTYPE = (overrides?: Partial<LISTTYPE>): LISTTYPE => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aLISTTYPE = (overrides?: Partial<LISTTYPE>, _selectionSet?: DocumentNode): LISTTYPE => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>): UPDATEUSERINPUT => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>, _selectionSet?: DocumentNode): UPDATEUSERINPUT => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMUTATION = (overrides?: Partial<MUTATION>): MUTATION => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER(),
+export const aMUTATION = (overrides?: Partial<MUTATION>, _selectionSet?: DocumentNode): MUTATION => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUSER(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPREFIXED_RESPONSE(),
+export const aQUERY = (overrides?: Partial<QUERY>, queryDocument?: DocumentNode): QUERY => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUSER({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPREFIXED_RESPONSE({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
@@ -2290,238 +2290,238 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 
 exports[`should generate single list element 1`] = `
 "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should not merge imports into one if enumsPrefix does not contain dots 1`] = `
 "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : ApiStatus.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ApiAbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : ApiPrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : ApiStatus.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ApiAbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : ApiPrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 
 exports[`should not merge imports into one if typesPrefix does not contain dots 1`] = `
 "import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiListType, ApiUpdateUserInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<ApiAvatar>): ApiAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+export const anAvatar = (overrides?: Partial<ApiAvatar>, _selectionSet?: DocumentNode): ApiAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
     };
-};
-
-export const aUser = (overrides?: Partial<ApiUser>): ApiUser => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+export const aUser = (overrides?: Partial<ApiUser>, _selectionSet?: DocumentNode): ApiUser => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<ApiWithAvatar>): ApiWithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<ApiWithAvatar>, _selectionSet?: DocumentNode): ApiWithAvatar => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<ApiCamelCaseThing>): ApiCamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<ApiCamelCaseThing>, _selectionSet?: DocumentNode): ApiCamelCaseThing => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<ApiPrefixedResponse>): ApiPrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<ApiPrefixedResponse>, _selectionSet?: DocumentNode): ApiPrefixedResponse => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
     };
-};
-
-export const anAbcType = (overrides?: Partial<ApiAbcType>): ApiAbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<ApiAbcType>, _selectionSet?: DocumentNode): ApiAbcType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
     };
-};
-
-export const aListType = (overrides?: Partial<ApiListType>): ApiListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ApiListType>, _selectionSet?: DocumentNode): ApiListType => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<ApiUpdateUserInput>): ApiUpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<ApiUpdateUserInput>, _selectionSet?: DocumentNode): ApiUpdateUserInput => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<ApiMutation>): ApiMutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<ApiMutation>, _selectionSet?: DocumentNode): ApiMutation => {
+        
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
     };
-};
-
-export const aQuery = (overrides?: Partial<ApiQuery>): ApiQuery => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<ApiQuery>, queryDocument?: DocumentNode): ApiQuery => {
+        const _selectionSet = queryDocument.definitions[0].selectionSet;
+        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
+        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
     };
-};
 "
 `;
 

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -2238,81 +2238,82 @@ export const aQUERY = (overrides?: Partial<QUERY>, queryDocument?: DocumentNode)
 `;
 
 exports[`should generate multiple list elements 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
         creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id', 'soluta', 'quis'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id', 'soluta', 'quis'],};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
-};
 "
 `;
 

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1,943 +1,955 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should add custom prefix if the \`prefix\` config option is specified 1`] = `
-"export const mockAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const mockAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const mockUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const mockUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : mockCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : mockAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : mockAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : mockCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : mockAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const mockWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const mockWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : mockAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const mockCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const mockCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const mockPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const mockPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const mockAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const mockAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const mockListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const mockListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const mockUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const mockUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : mockAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const mockMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const mockMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : mockUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : mockUser({}, attributesSelectionSet?.updateUser),};
     };
 export const mockQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : mockUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : mockPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : mockUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : mockPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should add enumsPrefix to all enums when option is specified 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should add enumsPrefix to imports 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, Api } from './types/graphql';
-export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, Api } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should add typesPrefix and enumsPrefix to imports 1`] = `
-"import { Api } from './types/graphql';
-export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: DocumentNode): Api.Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Api } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: SelectionSetNode): Api.Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: DocumentNode): Api.User => {
+export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: SelectionSetNode): Api.User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: DocumentNode): Api.WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: SelectionSetNode): Api.WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: DocumentNode): Api.CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: SelectionSetNode): Api.CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: DocumentNode): Api.PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: SelectionSetNode): Api.PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: DocumentNode): Api.AbcType => {
+export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: SelectionSetNode): Api.AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: DocumentNode): Api.ListType => {
+export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: SelectionSetNode): Api.ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: DocumentNode): Api.UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: SelectionSetNode): Api.UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: DocumentNode): Api.Mutation => {
+export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: SelectionSetNode): Api.Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should add typesPrefix to all types when option is specified 1`] = `
-"export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: DocumentNode): Api.Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: SelectionSetNode): Api.Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: DocumentNode): Api.User => {
+export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: SelectionSetNode): Api.User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: DocumentNode): Api.WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: SelectionSetNode): Api.WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: DocumentNode): Api.CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: SelectionSetNode): Api.CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: DocumentNode): Api.PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: SelectionSetNode): Api.PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: DocumentNode): Api.AbcType => {
+export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: SelectionSetNode): Api.AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: DocumentNode): Api.ListType => {
+export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: SelectionSetNode): Api.ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: DocumentNode): Api.UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: SelectionSetNode): Api.UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: DocumentNode): Api.Mutation => {
+export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: SelectionSetNode): Api.Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should add typesPrefix to imports 1`] = `
-"import { Api, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: DocumentNode): Api.Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Api, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Api.Avatar>, _selectionSet?: SelectionSetNode): Api.Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: DocumentNode): Api.User => {
+export const aUser = (overrides?: Partial<Api.User>, _selectionSet?: SelectionSetNode): Api.User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: DocumentNode): Api.WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>, _selectionSet?: SelectionSetNode): Api.WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: DocumentNode): Api.CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>, _selectionSet?: SelectionSetNode): Api.CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: DocumentNode): Api.PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>, _selectionSet?: SelectionSetNode): Api.PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: DocumentNode): Api.AbcType => {
+export const anAbcType = (overrides?: Partial<Api.AbcType>, _selectionSet?: SelectionSetNode): Api.AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: DocumentNode): Api.ListType => {
+export const aListType = (overrides?: Partial<Api.ListType>, _selectionSet?: SelectionSetNode): Api.ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: DocumentNode): Api.UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>, _selectionSet?: SelectionSetNode): Api.UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: DocumentNode): Api.Mutation => {
+export const aMutation = (overrides?: Partial<Api.Mutation>, _selectionSet?: SelectionSetNode): Api.Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Api.Query>, queryDocument?: DocumentNode): Api.Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should correctly generate the \`casual\` data for a function with arguments scalar mapping 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should correctly generate the \`casual\` data for a function with one argument scalar mapping 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should correctly generate the \`casual\` data for a non-string scalar mapping 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,98,185] }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,98,185],
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should correctly generate the \`casual\` data for a scalar mapping of type string 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should correctly use custom generator as default value 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : myValueGenerator() }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : myValueGenerator(),
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate dynamic values in mocks 1`] = `
-"import casual from 'casual';
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import casual from 'casual';
 
 casual.seed(0);
-export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : casual.word }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : casual.word,};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : new Date(casual.unix_time).toISOString() }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : casual.word }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : casual.word }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : new Date(casual.unix_time).toISOString(),
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : casual.word,
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : casual.word,
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : casual.word }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : casual.word,};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : casual.word }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : casual.word,};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [casual.word] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [casual.word],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : casual.word,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 
 export const seedMocks = (seed: number) => casual.seed(seed);
@@ -945,82 +957,83 @@ export const seedMocks = (seed: number) => casual.seed(seed);
 `;
 
 exports[`should generate dynamic values with faker 1`] = `
-"import { faker } from '@faker-js/faker';
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { faker } from '@faker-js/faker';
 
 faker.seed(0);
-export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid() }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : faker.lorem.word() }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : faker.lorem.word(),};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid() }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : faker.date.past(1, new Date(2022, 0)).toISOString() }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : faker.lorem.word() }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : faker.lorem.word() }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : faker.date.past(1, new Date(2022, 0)).toISOString(),
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : faker.lorem.word(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : faker.lorem.word(),
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid() }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid() }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : faker.lorem.word() }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : faker.lorem.word(),};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : faker.lorem.word() }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : faker.lorem.word(),};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [faker.lorem.word()] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [faker.lorem.word()],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : faker.lorem.word(),
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 
 export const seedMocks = (seed: number) => faker.seed(seed);
@@ -1028,1183 +1041,1198 @@ export const seedMocks = (seed: number) => faker.seed(seed);
 `;
 
 exports[`should generate mock data functions 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data functions with casual 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data functions with external types file import 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data functions with faker 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-bc38-ef1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-bc38-ef1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-9a7d-c13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-9a7d-c13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-8230-d4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-8230-d4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-900f-beee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-900f-beee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-9e5f-14155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'eos',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data functions with scalars 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
         creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
-};
 "
 `;
 
 exports[`should generate mock data with PascalCase enum values by default 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with PascalCase enum values if enumValues is "pascal-case#pascalCase" 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with PascalCase enum values if typenames is "pascal-case#pascalCase" 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with PascalCase types and enums by default 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with as-is enum values if enumValues is "keep" 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.hasXYZStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.hasXYZStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with as-is types and enums if typenames is "keep" 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : acamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as camelCaseThing : acamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const acamelCaseThing = (overrides?: Partial<camelCaseThing>, _selectionSet?: DocumentNode): camelCaseThing => {
+export const acamelCaseThing = (overrides?: Partial<camelCaseThing>, _selectionSet?: SelectionSetNode): camelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>, _selectionSet?: DocumentNode): Prefixed_Response => {
+export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>, _selectionSet?: SelectionSetNode): Prefixed_Response => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anABCType = (overrides?: Partial<ABCType>, _selectionSet?: DocumentNode): ABCType => {
+export const anABCType = (overrides?: Partial<ABCType>, _selectionSet?: SelectionSetNode): ABCType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as Prefixed_Response : aPrefixed_Response({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with typename if addTypename is true 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): { __typename: 'Avatar' } & Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): { __typename: 'Avatar' } & Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
-        
-        return {
-        __typename: 'Avatar',        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
-    };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): { __typename: 'User' } & User => {
-        
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
-        __typename: 'User',        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        __typename: 'Avatar',        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): { __typename: 'WithAvatar' } & WithAvatar => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): { __typename: 'User' } & User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
-        __typename: 'WithAvatar',        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        __typename: 'User',        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): { __typename: 'camelCaseThing' } & CamelCaseThing => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): { __typename: 'WithAvatar' } & WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
-        __typename: 'camelCaseThing',        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        __typename: 'WithAvatar',        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): { __typename: 'Prefixed_Response' } & PrefixedResponse => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): { __typename: 'camelCaseThing' } & CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
-        __typename: 'Prefixed_Response',        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        __typename: 'camelCaseThing',        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): { __typename: 'ABCType' } & AbcType => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): { __typename: 'Prefixed_Response' } & PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
-        __typename: 'ABCType',        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        __typename: 'Prefixed_Response',        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): { __typename: 'ListType' } & ListType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): { __typename: 'ABCType' } & AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
-        __typename: 'ListType',        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        __typename: 'ABCType',        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): { __typename: 'ListType' } & ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {
+        __typename: 'ListType',        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
+    };
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): { __typename: 'Mutation' } & Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): { __typename: 'Mutation' } & Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
-        __typename: 'Mutation',        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        __typename: 'Mutation',        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): { __typename: 'Query' } & Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {
-        __typename: 'Query',        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        __typename: 'Query',        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with upperCase enum values if enumValues is "upper-case#upperCase" 1`] = `
-"export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HASXYZSTATUS }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HASXYZSTATUS,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with upperCase types and enums if typenames is "upper-case#upperCase" 1`] = `
-"export const anAVATAR = (overrides?: Partial<AVATAR>, _selectionSet?: DocumentNode): AVATAR => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAVATAR = (overrides?: Partial<AVATAR>, _selectionSet?: SelectionSetNode): AVATAR => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUSER = (overrides?: Partial<USER>, _selectionSet?: DocumentNode): USER => {
+export const aUSER = (overrides?: Partial<USER>, _selectionSet?: SelectionSetNode): USER => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as AVATAR : anAVATAR({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CAMELCASETHING : aCAMELCASETHING({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as AVATAR : anAVATAR({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue,};
     };
-export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>, _selectionSet?: DocumentNode): WITHAVATAR => {
+export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>, _selectionSet?: SelectionSetNode): WITHAVATAR => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as AVATAR : anAVATAR({}, attributesSelectionSet?.avatar),};
     };
-export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>, _selectionSet?: DocumentNode): CAMELCASETHING => {
+export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>, _selectionSet?: SelectionSetNode): CAMELCASETHING => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>, _selectionSet?: DocumentNode): PREFIXED_RESPONSE => {
+export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>, _selectionSet?: SelectionSetNode): PREFIXED_RESPONSE => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anABCTYPE = (overrides?: Partial<ABCTYPE>, _selectionSet?: DocumentNode): ABCTYPE => {
+export const anABCTYPE = (overrides?: Partial<ABCTYPE>, _selectionSet?: SelectionSetNode): ABCTYPE => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aLISTTYPE = (overrides?: Partial<LISTTYPE>, _selectionSet?: DocumentNode): LISTTYPE => {
+export const aLISTTYPE = (overrides?: Partial<LISTTYPE>, _selectionSet?: SelectionSetNode): LISTTYPE => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>, _selectionSet?: DocumentNode): UPDATEUSERINPUT => {
+export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>, _selectionSet?: SelectionSetNode): UPDATEUSERINPUT => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as AVATAR : anAVATAR({}, attributesSelectionSet?.avatar),};
     };
-export const aMUTATION = (overrides?: Partial<MUTATION>, _selectionSet?: DocumentNode): MUTATION => {
+export const aMUTATION = (overrides?: Partial<MUTATION>, _selectionSet?: SelectionSetNode): MUTATION => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as USER : aUSER({}, attributesSelectionSet?.updateUser),};
     };
 export const aQUERY = (overrides?: Partial<QUERY>, queryDocument?: DocumentNode): QUERY => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUSER({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPREFIXED_RESPONSE({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as USER : aUSER({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PREFIXED_RESPONSE : aPREFIXED_RESPONSE({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should generate mock data with upperCase types and imports if typenames is "upper-case#upperCase" 1`] = `
-"import { AVATAR, USER, WITHAVATAR, CAMELCASETHING, PREFIXED_RESPONSE, ABCTYPE, LISTTYPE, UPDATEUSERINPUT, MUTATION, QUERY, ABCSTATUS, STATUS, PREFIXED_ENUM } from './types/graphql';
-export const anAVATAR = (overrides?: Partial<AVATAR>, _selectionSet?: DocumentNode): AVATAR => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { AVATAR, USER, WITHAVATAR, CAMELCASETHING, PREFIXED_RESPONSE, ABCTYPE, LISTTYPE, UPDATEUSERINPUT, MUTATION, QUERY, ABCSTATUS, STATUS, PREFIXED_ENUM } from './types/graphql';
+export const anAVATAR = (overrides?: Partial<AVATAR>, _selectionSet?: SelectionSetNode): AVATAR => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUSER = (overrides?: Partial<USER>, _selectionSet?: DocumentNode): USER => {
+export const aUSER = (overrides?: Partial<USER>, _selectionSet?: SelectionSetNode): USER => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as AVATAR : anAVATAR({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CAMELCASETHING : aCAMELCASETHING({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as AVATAR : anAVATAR({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue,};
     };
-export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>, _selectionSet?: DocumentNode): WITHAVATAR => {
+export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>, _selectionSet?: SelectionSetNode): WITHAVATAR => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as AVATAR : anAVATAR({}, attributesSelectionSet?.avatar),};
     };
-export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>, _selectionSet?: DocumentNode): CAMELCASETHING => {
+export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>, _selectionSet?: SelectionSetNode): CAMELCASETHING => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>, _selectionSet?: DocumentNode): PREFIXED_RESPONSE => {
+export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>, _selectionSet?: SelectionSetNode): PREFIXED_RESPONSE => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anABCTYPE = (overrides?: Partial<ABCTYPE>, _selectionSet?: DocumentNode): ABCTYPE => {
+export const anABCTYPE = (overrides?: Partial<ABCTYPE>, _selectionSet?: SelectionSetNode): ABCTYPE => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aLISTTYPE = (overrides?: Partial<LISTTYPE>, _selectionSet?: DocumentNode): LISTTYPE => {
+export const aLISTTYPE = (overrides?: Partial<LISTTYPE>, _selectionSet?: SelectionSetNode): LISTTYPE => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>, _selectionSet?: DocumentNode): UPDATEUSERINPUT => {
+export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>, _selectionSet?: SelectionSetNode): UPDATEUSERINPUT => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as AVATAR : anAVATAR({}, attributesSelectionSet?.avatar),};
     };
-export const aMUTATION = (overrides?: Partial<MUTATION>, _selectionSet?: DocumentNode): MUTATION => {
+export const aMUTATION = (overrides?: Partial<MUTATION>, _selectionSet?: SelectionSetNode): MUTATION => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as USER : aUSER({}, attributesSelectionSet?.updateUser),};
     };
 export const aQUERY = (overrides?: Partial<QUERY>, queryDocument?: DocumentNode): QUERY => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUSER({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPREFIXED_RESPONSE({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as USER : aUSER({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PREFIXED_RESPONSE : aPREFIXED_RESPONSE({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
@@ -2289,405 +2317,400 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should generate single list element 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should not merge imports into one if enumsPrefix does not contain dots 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';
-export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: DocumentNode): Avatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<User>, _selectionSet?: DocumentNode): User => {
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : ApiStatus.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ApiAbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : ApiPrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : ApiStatus.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ApiAbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : ApiPrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: DocumentNode): WithAvatar => {
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: DocumentNode): CamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: DocumentNode): PrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _selectionSet?: SelectionSetNode): PrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: DocumentNode): AbcType => {
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ListType>, _selectionSet?: DocumentNode): ListType => {
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: DocumentNode): UpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: DocumentNode): Mutation => {
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should not merge imports into one if typesPrefix does not contain dots 1`] = `
-"import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiListType, ApiUpdateUserInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';
-export const anAvatar = (overrides?: Partial<ApiAvatar>, _selectionSet?: DocumentNode): ApiAvatar => {
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiListType, ApiUpdateUserInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+export const anAvatar = (overrides?: Partial<ApiAvatar>, _selectionSet?: SelectionSetNode): ApiAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.url ? {} : { url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-export const aUser = (overrides?: Partial<ApiUser>, _selectionSet?: DocumentNode): ApiUser => {
+export const aUser = (overrides?: Partial<ApiUser>, _selectionSet?: SelectionSetNode): ApiUser => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.creationDate ? {} : { creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.login ? {} : { login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.status ? {} : { status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.customStatus ? {} : { customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.scalarValue ? {} : { scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.camelCaseThing ? {} : { camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.unionThing ? {} : { unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar({}, attributesSelectionSet?.unionThing) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixedEnum ? {} : { prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-export const aWithAvatar = (overrides?: Partial<ApiWithAvatar>, _selectionSet?: DocumentNode): ApiWithAvatar => {
+export const aWithAvatar = (overrides?: Partial<ApiWithAvatar>, _selectionSet?: SelectionSetNode): ApiWithAvatar => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c' }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.avatar ? {} : { avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar) }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aCamelCaseThing = (overrides?: Partial<ApiCamelCaseThing>, _selectionSet?: DocumentNode): ApiCamelCaseThing => {
+export const aCamelCaseThing = (overrides?: Partial<ApiCamelCaseThing>, _selectionSet?: SelectionSetNode): ApiCamelCaseThing => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.id ? {} : { id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42' }),};
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-export const aPrefixedResponse = (overrides?: Partial<ApiPrefixedResponse>, _selectionSet?: DocumentNode): ApiPrefixedResponse => {
+export const aPrefixedResponse = (overrides?: Partial<ApiPrefixedResponse>, _selectionSet?: SelectionSetNode): ApiPrefixedResponse => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.ping ? {} : { ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt' }),};
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-export const anAbcType = (overrides?: Partial<ApiAbcType>, _selectionSet?: DocumentNode): ApiAbcType => {
+export const anAbcType = (overrides?: Partial<ApiAbcType>, _selectionSet?: SelectionSetNode): ApiAbcType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.abc ? {} : { abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit' }),};
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-export const aListType = (overrides?: Partial<ApiListType>, _selectionSet?: DocumentNode): ApiListType => {
+export const aListType = (overrides?: Partial<ApiListType>, _selectionSet?: SelectionSetNode): ApiListType => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.stringList ? {} : { stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'] }),};
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-export const anUpdateUserInput = (overrides?: Partial<ApiUpdateUserInput>, _selectionSet?: DocumentNode): ApiUpdateUserInput => {
+export const anUpdateUserInput = (overrides?: Partial<ApiUpdateUserInput>, _selectionSet?: SelectionSetNode): ApiUpdateUserInput => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
         return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar({}, attributesSelectionSet?.avatar),};
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-export const aMutation = (overrides?: Partial<ApiMutation>, _selectionSet?: DocumentNode): ApiMutation => {
+export const aMutation = (overrides?: Partial<ApiMutation>, _selectionSet?: SelectionSetNode): ApiMutation => {
         
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.updateUser ? {} : { updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser({}, attributesSelectionSet?.updateUser) }),};
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
 export const aQuery = (overrides?: Partial<ApiQuery>, queryDocument?: DocumentNode): ApiQuery => {
-        const _selectionSet = queryDocument.definitions[0].selectionSet;
-        const attributesSelectionSet = selectionSet ? Object.fromEntries(selectionSet.selections.map((selection) => [selection.name.value, selection.selectionSet ?? null])) : null;
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
         
-        return {        ...(attributesSelectionSet && !attributesSelectionSet?.user ? {} : { user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser({}, attributesSelectionSet?.user) }),
-        ...(attributesSelectionSet && !attributesSelectionSet?.prefixed_query ? {} : { prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query) }),};
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, attributesSelectionSet?.prefixed_query),};
     };
 "
 `;
 
 exports[`should preserve underscores if transformUnderscore is false 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';
-
-export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';
+export const anAvatar = (overrides?: Partial<Avatar>, _selectionSet?: SelectionSetNode): Avatar => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-};
-
-export const aUser = (overrides?: Partial<User>): User => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+export const aUser = (overrides?: Partial<User>, _selectionSet?: SelectionSetNode): User => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
         creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _selectionSet?: SelectionSetNode): WithAvatar => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _selectionSet?: SelectionSetNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-};
-
-export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>, _selectionSet?: SelectionSetNode): Prefixed_Response => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _selectionSet?: SelectionSetNode): AbcType => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _selectionSet?: SelectionSetNode): ListType => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _selectionSet?: SelectionSetNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+export const aMutation = (overrides?: Partial<Mutation>, _selectionSet?: SelectionSetNode): Mutation => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, attributesSelectionSet?.updateUser),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response(),
+export const aQuery = (overrides?: Partial<Query>, queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as Prefixed_Response : aPrefixed_Response({}, attributesSelectionSet?.prefixed_query),};
     };
-};
 "
 `;
 
 exports[`should use relationshipsToOmit argument to terminate circular relationships with terminateCircularRelationships enabled 1`] = `
-"
-export const anAvatar = (overrides?: Partial<Avatar>, _relationshipsToOmit: Array<string> = []): Avatar => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'Avatar']);
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anAvatar = (overrides?: Partial<Avatar>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): Avatar => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'Avatar']);
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',};
     };
-};
-
-export const aUser = (overrides?: Partial<User>, _relationshipsToOmit: Array<string> = []): User => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'User']);
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+export const aUser = (overrides?: Partial<User>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): User => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'User']);
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
         creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') || attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, relationshipsToOmit, attributesSelectionSet?.avatar),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : relationshipsToOmit.includes('CamelCaseThing') ? {} as CamelCaseThing : aCamelCaseThing({}, relationshipsToOmit),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : relationshipsToOmit.includes('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : relationshipsToOmit.includes('CamelCaseThing') || attributesSelectionSet && !attributesSelectionSet.camelCaseThing ? {} as CamelCaseThing : aCamelCaseThing({}, relationshipsToOmit, attributesSelectionSet?.camelCaseThing),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : relationshipsToOmit.includes('Avatar') || attributesSelectionSet && !attributesSelectionSet.unionThing ? {} as Avatar : anAvatar({}, relationshipsToOmit, attributesSelectionSet?.unionThing),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,};
     };
-};
-
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _relationshipsToOmit: Array<string> = []): WithAvatar => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'WithAvatar']);
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): WithAvatar => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'WithAvatar']);
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') || attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, relationshipsToOmit, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _relationshipsToOmit: Array<string> = []): CamelCaseThing => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'CamelCaseThing']);
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): CamelCaseThing => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'CamelCaseThing']);
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',};
     };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _relationshipsToOmit: Array<string> = []): PrefixedResponse => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'PrefixedResponse']);
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): PrefixedResponse => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'PrefixedResponse']);
+        return {        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',};
     };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>, _relationshipsToOmit: Array<string> = []): AbcType => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'AbcType']);
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+export const anAbcType = (overrides?: Partial<AbcType>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): AbcType => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'AbcType']);
+        return {        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',};
     };
-};
-
-export const aListType = (overrides?: Partial<ListType>, _relationshipsToOmit: Array<string> = []): ListType => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'ListType']);
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+export const aListType = (overrides?: Partial<ListType>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): ListType => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'ListType']);
+        return {        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],};
     };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _relationshipsToOmit: Array<string> = []): UpdateUserInput => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'UpdateUserInput']);
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): UpdateUserInput => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'UpdateUserInput']);
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') || attributesSelectionSet && !attributesSelectionSet.avatar ? {} as Avatar : anAvatar({}, relationshipsToOmit, attributesSelectionSet?.avatar),};
     };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>, _relationshipsToOmit: Array<string> = []): Mutation => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'Mutation']);
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : relationshipsToOmit.includes('User') ? {} as User : aUser({}, relationshipsToOmit),
+export const aMutation = (overrides?: Partial<Mutation>, _relationshipsToOmit: Array<string> = [], _selectionSet?: SelectionSetNode): Mutation => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'Mutation']);
+        return {        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : relationshipsToOmit.includes('User') || attributesSelectionSet && !attributesSelectionSet.updateUser ? {} as User : aUser({}, relationshipsToOmit, attributesSelectionSet?.updateUser),};
     };
-};
-
-export const aQuery = (overrides?: Partial<Query>, _relationshipsToOmit: Array<string> = []): Query => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'Query']);
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : relationshipsToOmit.includes('User') ? {} as User : aUser({}, relationshipsToOmit),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : relationshipsToOmit.includes('PrefixedResponse') ? {} as PrefixedResponse : aPrefixedResponse({}, relationshipsToOmit),
+export const aQuery = (overrides?: Partial<Query>, _relationshipsToOmit: Array<string> = [], queryDocument?: DocumentNode): Query => {
+        const _selectionSet = queryDocument?.definitions[0].selectionSet;
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        const relationshipsToOmit = ([..._relationshipsToOmit, 'Query']);
+        return {        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : relationshipsToOmit.includes('User') || attributesSelectionSet && !attributesSelectionSet.user ? {} as User : aUser({}, relationshipsToOmit, attributesSelectionSet?.user),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : relationshipsToOmit.includes('PrefixedResponse') || attributesSelectionSet && !attributesSelectionSet.prefixed_query ? {} as PrefixedResponse : aPrefixedResponse({}, relationshipsToOmit, attributesSelectionSet?.prefixed_query),};
     };
-};
 "
 `;

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -3,6 +3,7 @@ import { plugin } from '../src';
 import circularRelationshipsSchema from './terminateCircularRelationships/schema';
 import dynamicValuesSchema from './dynamicValues/schema';
 import generateLibrarySchema from './generateLibrary/schema';
+import queryDocumentsSchema from './queryDocuments/schema';
 
 export default async () => {
     const terminateCircularRelationshipsMocks = await plugin(circularRelationshipsSchema, [], {
@@ -23,4 +24,9 @@ export default async () => {
         generateLibrary: 'faker',
     });
     fs.writeFileSync('./tests/generateLibrary/faker/mocks.ts', generateWithFakerMocks.toString());
+
+    const queryDocumentsMocks = await plugin(queryDocumentsSchema, [], {
+        typesFile: './types.ts',
+    });
+    fs.writeFileSync('./tests/queryDocuments/mocks.ts', queryDocumentsMocks.toString());
 };

--- a/tests/queryDocuments/schema.ts
+++ b/tests/queryDocuments/schema.ts
@@ -1,0 +1,17 @@
+import { buildSchema } from 'graphql';
+
+export default buildSchema(/* GraphQL */ `
+    type Query {
+        A: A
+        B: B
+    }
+    type A {
+        obj1: B!
+        obj2: B!
+    }
+    type B {
+        b1: String!
+        b2: String!
+        b3: String!
+    }
+`);

--- a/tests/queryDocuments/spec.ts
+++ b/tests/queryDocuments/spec.ts
@@ -1,0 +1,49 @@
+import { DocumentNode, Kind, OperationTypeNode } from 'graphql';
+import { aQuery } from './mocks';
+
+it('should only return object fields present in the query document', () => {
+    const MOCKED_QUERY_DOCUMENT: DocumentNode = {
+        kind: Kind.DOCUMENT,
+        definitions: [
+            {
+                kind: Kind.OPERATION_DEFINITION,
+                operation: OperationTypeNode.QUERY,
+                selectionSet: {
+                    kind: Kind.SELECTION_SET,
+                    selections: [
+                        {
+                            kind: Kind.FIELD,
+                            name: { kind: Kind.NAME, value: 'A' },
+                            selectionSet: {
+                                kind: Kind.SELECTION_SET,
+                                selections: [
+                                    {
+                                        kind: Kind.FIELD,
+                                        name: { kind: Kind.NAME, value: 'obj1' },
+                                        selectionSet: {
+                                            kind: Kind.SELECTION_SET,
+                                            selections: [
+                                                {
+                                                    kind: Kind.FIELD,
+                                                    name: { kind: Kind.NAME, value: 'b2' },
+                                                },
+                                                {
+                                                    kind: Kind.FIELD,
+                                                    name: { kind: Kind.NAME, value: 'b3' },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+    };
+
+    const mockedQueryResponse = aQuery({}, MOCKED_QUERY_DOCUMENT);
+    expect(mockedQueryResponse.B).toEqual({});
+    expect(mockedQueryResponse.A.obj2).toEqual({});
+});

--- a/tests/queryDocuments/types.ts
+++ b/tests/queryDocuments/types.ts
@@ -1,0 +1,15 @@
+export type Query = {
+    A: A;
+    B: B;
+};
+
+export type A = {
+    obj1: B;
+    obj2: B;
+};
+
+export type B = {
+    b1: string;
+    b2: string;
+    b3: string;
+};

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -1,22 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should generate custom scalars for native and custom types 1`] = `
-"
-export const anA = (overrides?: Partial<A>): A => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,
+"import { DocumentNode, FieldNode, SelectionSetNode } from 'graphql'
+export const anA = (overrides?: Partial<A>, _selectionSet?: SelectionSetNode): A => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,
         str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Kelly_Cremin@Turcotte.biz',
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : attributesSelectionSet && !attributesSelectionSet.obj ? {} as B : aB({}, attributesSelectionSet?.obj),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Kelly_Cremin@Turcotte.biz',};
     };
-};
-
-export const aB = (overrides?: Partial<B>): B => {
-    return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
+export const aB = (overrides?: Partial<B>, _selectionSet?: SelectionSetNode): B => {
+        
+        const attributesSelectionSet = _selectionSet ? Object.fromEntries((_selectionSet.selections as FieldNode[]).map((selection) => [selection.name?.value, selection.selectionSet ?? null])) : null;
+        
+        return {        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
         flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,};
     };
-};
 "
 `;

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -386,7 +386,7 @@ it('should use relationshipsToOmit argument to terminate circular relationships 
     expect(result).toBeDefined();
     expect(result).toMatch(/const relationshipsToOmit = \(\[..._relationshipsToOmit, 'User']\)/);
     expect(result).toMatch(
-        /relationshipsToOmit.includes\('Avatar'\) \? {} as Avatar : anAvatar\({}, relationshipsToOmit\)/,
+        /relationshipsToOmit.includes\('Avatar'\) || attributesSelectionSet && !attributesSelectionSet.avatar \? {} as Avatar : anAvatar\({}, relationshipsToOmit, attributesSelectionSet\?.avatar\)/,
     );
     expect(result).not.toMatch(/: anAvatar\(\)/);
     expect(result).toMatchSnapshot();
@@ -403,7 +403,7 @@ it('should preserve underscores if transformUnderscore is false', async () => {
         "import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';",
     );
     expect(result).toContain(
-        'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
+        'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>, _selectionSet?: SelectionSetNode): Prefixed_Response => {',
     );
     expect(result).toContain(
         "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,",


### PR DESCRIPTION
Add a parameter to `aQuery` generated function to pass a query `DocumentNode` object and receive that query response without unnecessary information.