### PR TITLE
Rename `typenames` to `typeNames`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ keep all GraphQL names as-is. Available case functions in `change-case-all` are 
 `localeLowerCase`, `lowerCaseFirst`, `spongeCase`, `titleCase`, `upperCase`, `localeUpperCase` and `upperCaseFirst`
 [See more](https://github.com/btxtiger/change-case-all)
 
-### typenames (`string`, defaultValue: `change-case-all#pascalCase`)
+### typeNames (`string`, defaultValue: `change-case-all#pascalCase`)
 
 Changes the case of types. The format of the converter must be a valid `module#method`. You can also use `keep` to
 keep all GraphQL names as-is. Available case functions in `change-case-all` are `camelCase`, `capitalCase`, `constantCase`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -413,6 +413,10 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
     const printedSchema = printSchema(schema); // Returns a string representation of the schema
     const astNode = parse(printedSchema); // Transforms the string into ASTNode
 
+    if ('typenames' in config) {
+        throw new Error('Config `typenames` was renamed to `typeNames`. Please update your config');
+    }
+
     const enumValuesConvention = config.enumValues || 'change-case-all#pascalCase';
     const typeNamesConvention = config.typeNames || 'change-case-all#pascalCase';
     const transformUnderscore = config.transformUnderscore ?? true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ type Options<T = TypeNode> = {
     typeName: string;
     fieldName: string;
     types: TypeItem[];
-    typenamesConvention: NamingConvention;
+    typeNamesConvention: NamingConvention;
     enumValuesConvention: NamingConvention;
     terminateCircularRelationships: boolean;
     prefix: string | undefined;
@@ -175,7 +175,7 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
     });
     if (!opts.dynamicValues) mockValueGenerator.seed(hashedString(opts.typeName + opts.fieldName));
     const name = opts.currentType.name.value;
-    const casedName = createNameConverter(opts.typenamesConvention, opts.transformUnderscore)(name);
+    const casedName = createNameConverter(opts.typeNamesConvention, opts.transformUnderscore)(name);
     switch (name) {
         case 'String': {
             const customScalar = opts.customScalars ? getScalarDefinition(opts.customScalars['String']) : null;
@@ -204,7 +204,7 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
                     case 'enum': {
                         // It's an enum
                         const typenameConverter = createNameConverter(
-                            opts.typenamesConvention,
+                            opts.typeNamesConvention,
                             opts.transformUnderscore,
                         );
                         const enumConverter = createNameConverter(opts.enumValuesConvention, opts.transformUnderscore);
@@ -279,16 +279,16 @@ const generateMockValue = (opts: Options): string | number | boolean => {
 const getMockString = (
     typeName: string,
     fields: string,
-    typenamesConvention: NamingConvention,
+    typeNamesConvention: NamingConvention,
     terminateCircularRelationships: boolean,
     addTypename = false,
     prefix,
     typesPrefix = '',
     transformUnderscore: boolean,
 ) => {
-    const typenameConverter = createNameConverter(typenamesConvention, transformUnderscore);
-    const casedName = typenameConverter(typeName);
-    const casedNameWithPrefix = typenameConverter(typeName, typesPrefix);
+    const typeNameConverter = createNameConverter(typeNamesConvention, transformUnderscore);
+    const casedName = typeNameConverter(typeName);
+    const casedNameWithPrefix = typeNameConverter(typeName, typesPrefix);
     const typename = addTypename ? `\n        __typename: '${typeName}',` : '';
     const typenameReturnType = addTypename ? `{ __typename: '${typeName}' } & ` : '';
 
@@ -319,7 +319,7 @@ ${fields}
 };
 
 const getImportTypes = ({
-    typenamesConvention,
+    typeNamesConvention,
     definitions,
     types,
     typesFile,
@@ -327,7 +327,7 @@ const getImportTypes = ({
     enumsPrefix,
     transformUnderscore,
 }: {
-    typenamesConvention: NamingConvention;
+    typeNamesConvention: NamingConvention;
     definitions: any;
     types: TypeItem[];
     typesFile: string;
@@ -335,7 +335,7 @@ const getImportTypes = ({
     enumsPrefix: string;
     transformUnderscore: boolean;
 }) => {
-    const typenameConverter = createNameConverter(typenamesConvention, transformUnderscore);
+    const typenameConverter = createNameConverter(typeNamesConvention, transformUnderscore);
     const typeImports = typesPrefix?.endsWith('.')
         ? [typesPrefix.slice(0, -1)]
         : definitions
@@ -367,7 +367,7 @@ type ScalarMap = {
 export interface TypescriptMocksPluginConfig {
     typesFile?: string;
     enumValues?: NamingConvention;
-    typenames?: NamingConvention;
+    typeNames?: NamingConvention;
     addTypename?: boolean;
     prefix?: string;
     scalars?: ScalarMap;
@@ -414,7 +414,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
     const astNode = parse(printedSchema); // Transforms the string into ASTNode
 
     const enumValuesConvention = config.enumValues || 'change-case-all#pascalCase';
-    const typenamesConvention = config.typenames || 'change-case-all#pascalCase';
+    const typeNamesConvention = config.typeNames || 'change-case-all#pascalCase';
     const transformUnderscore = config.transformUnderscore ?? true;
     const listElementCount = config.listElementCount > 0 ? config.listElementCount : 1;
     const dynamicValues = !!config.dynamicValues;
@@ -452,7 +452,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                         typeName,
                         fieldName,
                         types,
-                        typenamesConvention,
+                        typeNamesConvention,
                         enumValuesConvention,
                         terminateCircularRelationships: !!config.terminateCircularRelationships,
                         prefix: config.prefix,
@@ -483,7 +483,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                                       typeName: fieldName,
                                       fieldName: field.name.value,
                                       types,
-                                      typenamesConvention,
+                                      typeNamesConvention,
                                       enumValuesConvention,
                                       terminateCircularRelationships: !!config.terminateCircularRelationships,
                                       prefix: config.prefix,
@@ -505,7 +505,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                     return getMockString(
                         fieldName,
                         mockFields,
-                        typenamesConvention,
+                        typeNamesConvention,
                         !!config.terminateCircularRelationships,
                         false,
                         config.prefix,
@@ -528,7 +528,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                     return getMockString(
                         typeName,
                         mockFields,
-                        typenamesConvention,
+                        typeNamesConvention,
                         !!config.terminateCircularRelationships,
                         !!config.addTypename,
                         config.prefix,
@@ -549,7 +549,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                     return getMockString(
                         typeName,
                         mockFields,
-                        typenamesConvention,
+                        typeNamesConvention,
                         !!config.terminateCircularRelationships,
                         !!config.addTypename,
                         config.prefix,
@@ -575,7 +575,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
     const typesFile = config.typesFile ? config.typesFile.replace(/\.[\w]+$/, '') : null;
 
     const typesFileImport = getImportTypes({
-        typenamesConvention,
+        typeNamesConvention,
         definitions,
         types,
         typesFile,

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1574,7 +1574,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 "
 `;
 
-exports[`should generate mock data with PascalCase enum values if typenames is "pascal-case#pascalCase" 1`] = `
+exports[`should generate mock data with PascalCase enum values if typeNames is "pascal-case#pascalCase" 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -1809,7 +1809,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 "
 `;
 
-exports[`should generate mock data with as-is types and enums if typenames is "keep" 1`] = `
+exports[`should generate mock data with as-is types and enums if typeNames is "keep" 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -2052,7 +2052,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 "
 `;
 
-exports[`should generate mock data with upperCase types and enums if typenames is "upper-case#upperCase" 1`] = `
+exports[`should generate mock data with upperCase types and enums if typeNames is "upper-case#upperCase" 1`] = `
 "
 export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
     return {
@@ -2130,7 +2130,7 @@ export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
 "
 `;
 
-exports[`should generate mock data with upperCase types and imports if typenames is "upper-case#upperCase" 1`] = `
+exports[`should generate mock data with upperCase types and imports if typeNames is "upper-case#upperCase" 1`] = `
 "import { AVATAR, USER, WITHAVATAR, CAMELCASETHING, PREFIXED_RESPONSE, ABCTYPE, LISTTYPE, UPDATEUSERINPUT, MUTATION, QUERY, ABCSTATUS, STATUS, PREFIXED_ENUM } from './types/graphql';
 
 export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -191,8 +191,8 @@ it('should generate mock data with PascalCase types and enums by default', async
     expect(result).toMatchSnapshot();
 });
 
-it('should generate mock data with PascalCase enum values if typenames is "pascal-case#pascalCase"', async () => {
-    const result = await plugin(testSchema, [], { typenames: 'pascal-case#pascalCase' });
+it('should generate mock data with PascalCase enum values if typeNames is "pascal-case#pascalCase"', async () => {
+    const result = await plugin(testSchema, [], { typeNames: 'pascal-case#pascalCase' });
 
     expect(result).toBeDefined();
     expect(result).toMatch(/Abc(Type|Status)/);
@@ -201,8 +201,8 @@ it('should generate mock data with PascalCase enum values if typenames is "pasca
     expect(result).toMatchSnapshot();
 });
 
-it('should generate mock data with upperCase types and enums if typenames is "upper-case#upperCase"', async () => {
-    const result = await plugin(testSchema, [], { typenames: 'upper-case#upperCase' });
+it('should generate mock data with upperCase types and enums if typeNames is "upper-case#upperCase"', async () => {
+    const result = await plugin(testSchema, [], { typeNames: 'upper-case#upperCase' });
 
     expect(result).toBeDefined();
     expect(result).not.toMatch(/Abc(Type|Status)/);
@@ -211,8 +211,8 @@ it('should generate mock data with upperCase types and enums if typenames is "up
     expect(result).toMatchSnapshot();
 });
 
-it('should generate mock data with upperCase types and imports if typenames is "upper-case#upperCase"', async () => {
-    const result = await plugin(testSchema, [], { typenames: 'upper-case#upperCase', typesFile: './types/graphql.ts' });
+it('should generate mock data with upperCase types and imports if typeNames is "upper-case#upperCase"', async () => {
+    const result = await plugin(testSchema, [], { typeNames: 'upper-case#upperCase', typesFile: './types/graphql.ts' });
 
     expect(result).toBeDefined();
     expect(result).not.toMatch(/Abc(Type|Status)/);
@@ -221,8 +221,8 @@ it('should generate mock data with upperCase types and imports if typenames is "
     expect(result).toMatchSnapshot();
 });
 
-it('should generate mock data with as-is types and enums if typenames is "keep"', async () => {
-    const result = await plugin(testSchema, [], { typenames: 'keep' });
+it('should generate mock data with as-is types and enums if typeNames is "keep"', async () => {
+    const result = await plugin(testSchema, [], { typeNames: 'keep' });
 
     expect(result).toBeDefined();
     expect(result).not.toMatch(/Abc(Type|Status)/);


### PR DESCRIPTION
Fixes #104 

This PR renames the `typename` config input to `typeNames` which matches the pattern used for other inputs.

This matches the naming conventions mentioned in the GQL Codegen docs here:

- https://the-guild.dev/graphql/codegen/docs/config-reference/naming-convention#upper-case-enum-values