### PR TITLE
fix: Change the relationshipsToOmit data structure from Array to Set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,7 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
                 }
             }
             if (opts.terminateCircularRelationships) {
-                return `relationshipsToOmit.includes('${casedName}') ? {} as ${casedName} : ${toMockName(
+                return `relationshipsToOmit.has('${casedName}') ? {} as ${casedName} : ${toMockName(
                     name,
                     casedName,
                     opts.prefix,
@@ -361,8 +361,9 @@ export const ${toMockName(
             typeName,
             casedName,
             prefix,
-        )} = (overrides?: Partial<${casedNameWithPrefix}>, _relationshipsToOmit: Array<string> = []): ${typenameReturnType}${casedNameWithPrefix} => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, '${casedName}']);
+        )} = (overrides?: Partial<${casedNameWithPrefix}>, _relationshipsToOmit: Set<string> = new Set()): ${typenameReturnType}${casedNameWithPrefix} => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('${casedName}');
     return {${typename}
 ${fields}
     };

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -2606,87 +2606,97 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 
 exports[`should use relationshipsToOmit argument to terminate circular relationships with terminateCircularRelationships enabled 1`] = `
 "
-export const anAvatar = (overrides?: Partial<Avatar>, _relationshipsToOmit: Array<string> = []): Avatar => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'Avatar']);
+export const anAvatar = (overrides?: Partial<Avatar>, _relationshipsToOmit: Set<string> = new Set()): Avatar => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('Avatar');
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
     };
 };
 
-export const aUser = (overrides?: Partial<User>, _relationshipsToOmit: Array<string> = []): User => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'User']);
+export const aUser = (overrides?: Partial<User>, _relationshipsToOmit: Set<string> = new Set()): User => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('User');
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
         creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : relationshipsToOmit.includes('CamelCaseThing') ? {} as CamelCaseThing : aCamelCaseThing({}, relationshipsToOmit),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : relationshipsToOmit.includes('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : relationshipsToOmit.has('CamelCaseThing') ? {} as CamelCaseThing : aCamelCaseThing({}, relationshipsToOmit),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
         prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
     };
 };
 
-export const aWithAvatar = (overrides?: Partial<WithAvatar>, _relationshipsToOmit: Array<string> = []): WithAvatar => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'WithAvatar']);
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _relationshipsToOmit: Set<string> = new Set()): WithAvatar => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('WithAvatar');
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
     };
 };
 
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _relationshipsToOmit: Array<string> = []): CamelCaseThing => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'CamelCaseThing']);
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _relationshipsToOmit: Set<string> = new Set()): CamelCaseThing => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('CamelCaseThing');
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
     };
 };
 
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _relationshipsToOmit: Array<string> = []): PrefixedResponse => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'PrefixedResponse']);
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _relationshipsToOmit: Set<string> = new Set()): PrefixedResponse => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('PrefixedResponse');
     return {
         ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
     };
 };
 
-export const anAbcType = (overrides?: Partial<AbcType>, _relationshipsToOmit: Array<string> = []): AbcType => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'AbcType']);
+export const anAbcType = (overrides?: Partial<AbcType>, _relationshipsToOmit: Set<string> = new Set()): AbcType => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('AbcType');
     return {
         abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
     };
 };
 
-export const aListType = (overrides?: Partial<ListType>, _relationshipsToOmit: Array<string> = []): ListType => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'ListType']);
+export const aListType = (overrides?: Partial<ListType>, _relationshipsToOmit: Set<string> = new Set()): ListType => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('ListType');
     return {
         stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
     };
 };
 
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _relationshipsToOmit: Array<string> = []): UpdateUserInput => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'UpdateUserInput']);
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _relationshipsToOmit: Set<string> = new Set()): UpdateUserInput => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('UpdateUserInput');
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.includes('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
     };
 };
 
-export const aMutation = (overrides?: Partial<Mutation>, _relationshipsToOmit: Array<string> = []): Mutation => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'Mutation']);
+export const aMutation = (overrides?: Partial<Mutation>, _relationshipsToOmit: Set<string> = new Set()): Mutation => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('Mutation');
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : relationshipsToOmit.includes('User') ? {} as User : aUser({}, relationshipsToOmit),
+        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : relationshipsToOmit.has('User') ? {} as User : aUser({}, relationshipsToOmit),
     };
 };
 
-export const aQuery = (overrides?: Partial<Query>, _relationshipsToOmit: Array<string> = []): Query => {
-    const relationshipsToOmit = ([..._relationshipsToOmit, 'Query']);
+export const aQuery = (overrides?: Partial<Query>, _relationshipsToOmit: Set<string> = new Set()): Query => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('Query');
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : relationshipsToOmit.includes('User') ? {} as User : aUser({}, relationshipsToOmit),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : relationshipsToOmit.includes('PrefixedResponse') ? {} as PrefixedResponse : aPrefixedResponse({}, relationshipsToOmit),
+        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : relationshipsToOmit.has('User') ? {} as User : aUser({}, relationshipsToOmit),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : relationshipsToOmit.has('PrefixedResponse') ? {} as PrefixedResponse : aPrefixedResponse({}, relationshipsToOmit),
     };
 };
 "

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -384,10 +384,9 @@ it('should use relationshipsToOmit argument to terminate circular relationships 
     const result = await plugin(testSchema, [], { terminateCircularRelationships: true });
 
     expect(result).toBeDefined();
-    expect(result).toMatch(/const relationshipsToOmit = \(\[..._relationshipsToOmit, 'User']\)/);
-    expect(result).toMatch(
-        /relationshipsToOmit.includes\('Avatar'\) \? {} as Avatar : anAvatar\({}, relationshipsToOmit\)/,
-    );
+    expect(result).toMatch(/const relationshipsToOmit: Set<string> = new Set\(_relationshipsToOmit\);/);
+    expect(result).toMatch(/relationshipsToOmit.add\('Avatar'\)/);
+    expect(result).toMatch(/relationshipsToOmit.has\('Avatar'\) \? {} as Avatar : anAvatar\({}, relationshipsToOmit\)/);
     expect(result).not.toMatch(/: anAvatar\(\)/);
     expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
- https://github.com/ardeois/graphql-codegen-typescript-mock-data/pull/77

In the previous PR, due to the immutability issue, the data structure was modified from set to array.

However, I found out late that it is possible to fix bugs while using Set.

I opened a fix PR because I was aware that there was a performance hit.