### PR TITLE
Allow custom field generation for Enum types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,6 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
                             undefined,
                             () => `${typenameConverter(foundType.name, opts.enumsPrefix)}.${enumConverter(value)}`,
                         );
-                        // return `${typenameConverter(foundType.name, opts.enumsPrefix)}.${enumConverter(value)}`;
                     }
                     case 'union':
                         // Return the first union type node.

--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,12 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
                         );
                         const enumConverter = createNameConverter(opts.enumValuesConvention, opts.transformUnderscore);
                         const value = foundType.values ? foundType.values[0] : '';
-                        return `${typenameConverter(foundType.name, opts.enumsPrefix)}.${enumConverter(value)}`;
+                        return handleValueGeneration(
+                            opts,
+                            undefined,
+                            () => `${typenameConverter(foundType.name, opts.enumsPrefix)}.${enumConverter(value)}`,
+                        );
+                        // return `${typenameConverter(foundType.name, opts.enumsPrefix)}.${enumConverter(value)}`;
                     }
                     case 'union':
                         // Return the first union type node.

--- a/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
+++ b/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
@@ -27,6 +27,14 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
 export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
@@ -55,6 +63,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 
@@ -89,6 +105,14 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
 export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
@@ -117,6 +141,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 
@@ -151,6 +183,14 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
 export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
@@ -179,6 +219,53 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
+export const seedMocks = (seed: number) => casual.seed(seed);
+"
+`;
+
+exports[`per type field generation with casual with dynamic values can overwrite an enum value 1`] = `
+"import casual from 'casual';
+
+casual.seed(0);
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : casual['email'],
     };
 };
 
@@ -213,6 +300,14 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
 export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
@@ -238,6 +333,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 "
@@ -266,6 +369,14 @@ export const aB = (overrides?: Partial<B>): B => {
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
     };
 };
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
 "
 `;
 
@@ -290,6 +401,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 "
@@ -318,6 +437,14 @@ export const aB = (overrides?: Partial<B>): B => {
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
     };
 };
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
 "
 `;
 
@@ -342,6 +469,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 "
@@ -370,6 +505,48 @@ export const aB = (overrides?: Partial<B>): B => {
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
     };
 };
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+"
+`;
+
+exports[`per type field generation with casual without dynamic values can overwrite an enum value 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'vel',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'Roosevelt.Oberbrunner@gmail.com',
+    };
+};
 "
 `;
 
@@ -394,6 +571,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 "
@@ -423,6 +608,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 
@@ -457,6 +650,14 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
 export const seedMocks = (seed: number) => faker.seed(seed);
 "
 `;
@@ -485,6 +686,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 
@@ -519,6 +728,14 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
 export const seedMocks = (seed: number) => faker.seed(seed);
 "
 `;
@@ -547,6 +764,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 
@@ -581,6 +806,53 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
+export const seedMocks = (seed: number) => faker.seed(seed);
+"
+`;
+
+exports[`per type field generation with faker with dynamic values can overwrite an enum value 1`] = `
+"import { faker } from '@faker-js/faker';
+
+faker.seed(0);
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : faker['helpers']['arrayElement'](...[[\\"active\\",\\"disabled\\"]]),
+    };
+};
+
 export const seedMocks = (seed: number) => faker.seed(seed);
 "
 `;
@@ -612,6 +884,14 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
 export const seedMocks = (seed: number) => faker.seed(seed);
 "
 `;
@@ -637,6 +917,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 "
@@ -665,6 +953,14 @@ export const aB = (overrides?: Partial<B>): B => {
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
     };
 };
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
 "
 `;
 
@@ -689,6 +985,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 "
@@ -717,6 +1021,14 @@ export const aB = (overrides?: Partial<B>): B => {
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
     };
 };
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
 "
 `;
 
@@ -743,6 +1055,48 @@ export const aB = (overrides?: Partial<B>): B => {
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
     };
 };
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+"
+`;
+
+exports[`per type field generation with faker without dynamic values can overwrite an enum value 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'my@email.com',
+    };
+};
 "
 `;
 
@@ -767,6 +1121,14 @@ export const aB = (overrides?: Partial<B>): B => {
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
         dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
     };
 };
 "

--- a/tests/perTypeFieldGeneration/schema.ts
+++ b/tests/perTypeFieldGeneration/schema.ts
@@ -4,6 +4,11 @@ export default buildSchema(/* GraphQL */ `
     scalar Date
     scalar DateTime
 
+    enum EnumExample {
+        LOREM
+        IPSUM
+    }
+
     type A {
         id: ID!
         str: String!
@@ -20,5 +25,11 @@ export default buildSchema(/* GraphQL */ `
         date: Date!
         overriddenDate: Date!
         dateTime: DateTime!
+    }
+
+    type C {
+        id: ID!
+        str: String!
+        enum: EnumExample!
     }
 `);

--- a/tests/perTypeFieldGeneration/spec.ts
+++ b/tests/perTypeFieldGeneration/spec.ts
@@ -18,6 +18,9 @@ jest.mock('@faker-js/faker', () => ({
         internet: {
             email: () => 'my@email.com',
         },
+        helpers: {
+            arrayElement: (arr: unknown[]) => arr[0],
+        },
         seed: jest.fn(),
     },
 }));
@@ -75,6 +78,22 @@ describe('per type field generation with faker', () => {
             );
             expect(result).toContain(
                 "overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['past']()",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
+        it('can overwrite an enum value', async () => {
+            const result = await plugin(testSchema, [], {
+                ...config,
+                fieldGeneration: {
+                    C: { enum: { generator: 'helpers.arrayElement', arguments: [['active', 'disabled']] } },
+                },
+            });
+            expect(result).toBeDefined();
+
+            expect(result).toContain(
+                `enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : faker['helpers']['arrayElement'](...[["active","disabled"]]),`,
             );
 
             expect(result).toMatchSnapshot();
@@ -240,6 +259,22 @@ describe('per type field generation with faker', () => {
             expect(result).toMatchSnapshot();
         });
 
+        it('can overwrite an enum value', async () => {
+            const result = await plugin(testSchema, [], {
+                ...config,
+                fieldGeneration: {
+                    C: { enum: 'internet.email' },
+                },
+            });
+            expect(result).toBeDefined();
+
+            expect(result).toContain(
+                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'my@email.com'",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
         it('can apply generator override to all fields of a specific name', async () => {
             const result = await plugin(testSchema, [], {
                 ...config,
@@ -384,6 +419,22 @@ describe('per type field generation with casual', () => {
             );
             expect(result).toContain(
                 "overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date']()",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
+        it('can overwrite an enum value', async () => {
+            const result = await plugin(testSchema, [], {
+                ...config,
+                fieldGeneration: {
+                    C: { enum: 'email' },
+                },
+            });
+            expect(result).toBeDefined();
+
+            expect(result).toContain(
+                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : casual['email'],",
             );
 
             expect(result).toMatchSnapshot();
@@ -544,6 +595,22 @@ describe('per type field generation with casual', () => {
             );
             expect(result).toContain(
                 "overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05'",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
+        it('can overwrite an enum value', async () => {
+            const result = await plugin(testSchema, [], {
+                ...config,
+                fieldGeneration: {
+                    C: { enum: 'email' },
+                },
+            });
+            expect(result).toBeDefined();
+
+            expect(result).toContain(
+                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'Roosevelt.Oberbrunner@gmail.com'",
             );
 
             expect(result).toMatchSnapshot();


### PR DESCRIPTION
Fixes #110 

Extends the use of `handleFieldGeneration` into the Enum generation. This ensures any options which contain custom field generation are also applied there.

Tests have been added to verify the behaviour.