### PR TITLE
feat: add support for enumsAsTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Defines the file path containing all GraphQL types. This file can also be genera
 
 Adds `__typename` property to mock data
 
+### enumsAsTypes (`boolean`, defaultValue: `false`)
+
+Changes enums to TypeScript string union types
+
 ### terminateCircularRelationships (`boolean`, defaultValue: `false`)
 
 When enabled, prevents circular relationships from triggering infinite recursion. After the first resolution of a

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1731,6 +1731,84 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 "
 `;
 
+exports[`should generate mock data with as-is enum values as string union type if enumsAsTypes is true and enumValues is "keep" 1`] = `
+"
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'hasXYZStatus',
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',
+    };
+};
+
+export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+    };
+};
+
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
+    return {
+        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+    };
+};
+
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const aListType = (overrides?: Partial<ListType>): ListType => {
+    return {
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
+    return {
+        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+    };
+};
+
+export const aQuery = (overrides?: Partial<Query>): Query => {
+    return {
+        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+    };
+};
+"
+`;
+
 exports[`should generate mock data with as-is enum values if enumValues is "keep" 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
@@ -1882,6 +1960,84 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
         user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
         prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response(),
+    };
+};
+"
+`;
+
+exports[`should generate mock data with enum values as string union type if enumsAsTypes is true 1`] = `
+"
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'Online',
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'HasXyzStatus',
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PrefixedValue',
+    };
+};
+
+export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+    };
+};
+
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
+    return {
+        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+    };
+};
+
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const aListType = (overrides?: Partial<ListType>): ListType => {
+    return {
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
+    return {
+        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+    };
+};
+
+export const aQuery = (overrides?: Partial<Query>): Query => {
+    return {
+        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
     };
 };
 "
@@ -2547,6 +2703,85 @@ export const aUser = (overrides?: Partial<User>): User => {
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
         prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.Prefixed_Value,
+    };
+};
+
+export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+    };
+};
+
+export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {
+    return {
+        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+    };
+};
+
+export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+    };
+};
+
+export const aListType = (overrides?: Partial<ListType>): ListType => {
+    return {
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+    };
+};
+
+export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
+    return {
+        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+    };
+};
+
+export const aQuery = (overrides?: Partial<Query>): Query => {
+    return {
+        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response(),
+    };
+};
+"
+`;
+
+exports[`should preserve underscores if transformUnderscore is false and enumsAsTypes is true 1`] = `
+"import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, Mutation, Query } from './types/graphql';
+
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'Online',
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'HasXyzStatus',
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'Prefixed_Value',
     };
 };
 

--- a/tests/enumValues/__snapshots__/spec.ts.snap
+++ b/tests/enumValues/__snapshots__/spec.ts.snap
@@ -14,6 +14,20 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
 "
 `;
 
+exports[`enumValues config having 'change-case-all#pascalCase' value should keep underscores if 'transformUnderscore' is false and 'enumsAsTypes' is true 1`] = `
+"
+export const aMyType = (overrides?: Partial<MyType>): MyType => {
+    return {
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_Id',
+        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
+        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'CamelCase',
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'Snake_Case',
+        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'Screaming_Snake_Case',
+    };
+};
+"
+`;
+
 exports[`enumValues config having 'change-case-all#pascalCase' value should update case in pascal case 1`] = `
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
@@ -37,6 +51,20 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CAMELCASE,
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SNAKE_CASE,
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+    };
+};
+"
+`;
+
+exports[`enumValues config having 'change-case-all#upperCase' value should keep underscores if 'transformUnderscore' is false and 'enumsAsTypes' is true 1`] = `
+"
+export const aMyType = (overrides?: Partial<MyType>): MyType => {
+    return {
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_ID',
+        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PASCALCASE',
+        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'CAMELCASE',
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'SNAKE_CASE',
+        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
     };
 };
 "
@@ -70,6 +98,20 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
 "
 `;
 
+exports[`enumValues config having 'keep' value should have no effect if 'transformUnderscore' is false and 'enumsAsTypes' is true 1`] = `
+"
+export const aMyType = (overrides?: Partial<MyType>): MyType => {
+    return {
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_id',
+        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
+        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
+        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
+    };
+};
+"
+`;
+
 exports[`enumValues config having 'keep' value should keep case 1`] = `
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
@@ -93,6 +135,20 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.Snake_Case,
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.Screaming_Snake_Case,
+    };
+};
+"
+`;
+
+exports[`enumValues config having default value should keep underscores if 'transformUnderscore' is false and 'enumsAsTypes' is true 1`] = `
+"
+export const aMyType = (overrides?: Partial<MyType>): MyType => {
+    return {
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_Id',
+        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
+        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'CamelCase',
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'Snake_Case',
+        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'Screaming_Snake_Case',
     };
 };
 "

--- a/tests/enumValues/spec.ts
+++ b/tests/enumValues/spec.ts
@@ -31,6 +31,22 @@ describe('enumValues config', () => {
             expect(result).toContain('ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE');
             expect(result).toMatchSnapshot();
         });
+
+        it(`should have no effect if 'transformUnderscore' is false and 'enumsAsTypes' is true`, async () => {
+            const result = await plugin(enumSchema, [], {
+                enumValues: 'keep',
+                transformUnderscore: false,
+                enumsAsTypes: true,
+            });
+
+            expect(result).toBeDefined();
+            expect(result).toContain('_id');
+            expect(result).toContain('PascalCase');
+            expect(result).toContain('camelCase');
+            expect(result).toContain('snake_case');
+            expect(result).toContain('SCREAMING_SNAKE_CASE');
+            expect(result).toMatchSnapshot();
+        });
     });
 
     describe(`having default value`, () => {
@@ -57,6 +73,21 @@ describe('enumValues config', () => {
             expect(result).toContain('CamelCaseEnum.CamelCase');
             expect(result).toContain('SnakeCaseEnum.Snake_Case');
             expect(result).toContain('ScreamingSnakeCaseEnum.Screaming_Snake_Case');
+            expect(result).toMatchSnapshot();
+        });
+
+        it(`should keep underscores if 'transformUnderscore' is false and 'enumsAsTypes' is true`, async () => {
+            const result = await plugin(enumSchema, [], {
+                transformUnderscore: false,
+                enumsAsTypes: true,
+            });
+
+            expect(result).toBeDefined();
+            expect(result).toContain('_Id');
+            expect(result).toContain('PascalCase');
+            expect(result).toContain('CamelCase');
+            expect(result).toContain('Snake_Case');
+            expect(result).toContain('Screaming_Snake_Case');
             expect(result).toMatchSnapshot();
         });
     });
@@ -90,6 +121,22 @@ describe('enumValues config', () => {
             expect(result).toContain('ScreamingSnakeCaseEnum.Screaming_Snake_Case');
             expect(result).toMatchSnapshot();
         });
+
+        it(`should keep underscores if 'transformUnderscore' is false and 'enumsAsTypes' is true`, async () => {
+            const result = await plugin(enumSchema, [], {
+                enumValues: 'change-case-all#pascalCase',
+                transformUnderscore: false,
+                enumsAsTypes: true,
+            });
+
+            expect(result).toBeDefined();
+            expect(result).toContain('_Id');
+            expect(result).toContain('PascalCase');
+            expect(result).toContain('CamelCase');
+            expect(result).toContain('Snake_Case');
+            expect(result).toContain('Screaming_Snake_Case');
+            expect(result).toMatchSnapshot();
+        });
     });
 
     describe(`having 'change-case-all#upperCase' value`, () => {
@@ -120,6 +167,23 @@ describe('enumValues config', () => {
             expect(result).toContain('CamelCaseEnum.CAMELCASE');
             expect(result).toContain('SnakeCaseEnum.SNAKE_CASE');
             expect(result).toContain('ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE');
+            expect(result).toMatchSnapshot();
+        });
+
+        it(`should keep underscores if 'transformUnderscore' is false and 'enumsAsTypes' is true`, async () => {
+            const result = await plugin(enumSchema, [], {
+                enumValues: 'change-case-all#upperCase',
+                transformUnderscore: false,
+                enumsAsTypes: true,
+            });
+
+            expect(result).toBeDefined();
+            expect(result).toBeDefined();
+            expect(result).toContain('_ID');
+            expect(result).toContain('PASCALCASE');
+            expect(result).toContain('CAMELCASE');
+            expect(result).toContain('SNAKE_CASE');
+            expect(result).toContain('SCREAMING_SNAKE_CASE');
             expect(result).toMatchSnapshot();
         });
     });

--- a/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
+++ b/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
@@ -273,6 +273,45 @@ export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
 
+exports[`per type field generation with casual with dynamic values can overwrite an enum value when enumsAsTypes is true 1`] = `
+"import casual from 'casual';
+
+casual.seed(0);
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : casual['email'],
+    };
+};
+
+export const seedMocks = (seed: number) => casual.seed(seed);
+"
+`;
+
 exports[`per type field generation with casual with dynamic values uses per field generation if field name matches 1`] = `
 "import casual from 'casual';
 
@@ -517,6 +556,40 @@ export const aC = (overrides?: Partial<C>): C => {
 `;
 
 exports[`per type field generation with casual without dynamic values can overwrite an enum value 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'vel',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'Roosevelt.Oberbrunner@gmail.com',
+    };
+};
+"
+`;
+
+exports[`per type field generation with casual without dynamic values can overwrite an enum value when enumsAsTypes is true 1`] = `
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
@@ -857,6 +930,45 @@ export const seedMocks = (seed: number) => faker.seed(seed);
 "
 `;
 
+exports[`per type field generation with faker with dynamic values can overwrite an enum value when enumsAsTypes is true 1`] = `
+"import { faker } from '@faker-js/faker';
+
+faker.seed(0);
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : faker['helpers']['arrayElement'](...[[\\"active\\",\\"disabled\\"]]),
+    };
+};
+
+export const seedMocks = (seed: number) => faker.seed(seed);
+"
+`;
+
 exports[`per type field generation with faker with dynamic values uses per field generation if field name matches 1`] = `
 "import { faker } from '@faker-js/faker';
 
@@ -1067,6 +1179,40 @@ export const aC = (overrides?: Partial<C>): C => {
 `;
 
 exports[`per type field generation with faker without dynamic values can overwrite an enum value 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'my@email.com',
+    };
+};
+"
+`;
+
+exports[`per type field generation with faker without dynamic values can overwrite an enum value when enumsAsTypes is true 1`] = `
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {

--- a/tests/perTypeFieldGeneration/spec.ts
+++ b/tests/perTypeFieldGeneration/spec.ts
@@ -99,6 +99,23 @@ describe('per type field generation with faker', () => {
             expect(result).toMatchSnapshot();
         });
 
+        it('can overwrite an enum value when enumsAsTypes is true', async () => {
+            const result = await plugin(testSchema, [], {
+                ...config,
+                fieldGeneration: {
+                    C: { enum: { generator: 'helpers.arrayElement', arguments: [['active', 'disabled']] } },
+                },
+                enumsAsTypes: true,
+            });
+            expect(result).toBeDefined();
+
+            expect(result).toContain(
+                `enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : faker['helpers']['arrayElement'](...[["active","disabled"]]),`,
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
         it('can apply generator override to all fields of a specific name', async () => {
             const result = await plugin(testSchema, [], {
                 ...config,
@@ -275,6 +292,23 @@ describe('per type field generation with faker', () => {
             expect(result).toMatchSnapshot();
         });
 
+        it('can overwrite an enum value when enumsAsTypes is true', async () => {
+            const result = await plugin(testSchema, [], {
+                ...config,
+                fieldGeneration: {
+                    C: { enum: 'internet.email' },
+                },
+                enumsAsTypes: true,
+            });
+            expect(result).toBeDefined();
+
+            expect(result).toContain(
+                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'my@email.com'",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
         it('can apply generator override to all fields of a specific name', async () => {
             const result = await plugin(testSchema, [], {
                 ...config,
@@ -430,6 +464,23 @@ describe('per type field generation with casual', () => {
                 fieldGeneration: {
                     C: { enum: 'email' },
                 },
+            });
+            expect(result).toBeDefined();
+
+            expect(result).toContain(
+                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : casual['email'],",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
+        it('can overwrite an enum value when enumsAsTypes is true', async () => {
+            const result = await plugin(testSchema, [], {
+                ...config,
+                fieldGeneration: {
+                    C: { enum: 'email' },
+                },
+                enumsAsTypes: true,
             });
             expect(result).toBeDefined();
 
@@ -606,6 +657,23 @@ describe('per type field generation with casual', () => {
                 fieldGeneration: {
                     C: { enum: 'email' },
                 },
+            });
+            expect(result).toBeDefined();
+
+            expect(result).toContain(
+                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'Roosevelt.Oberbrunner@gmail.com'",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
+        it('can overwrite an enum value when enumsAsTypes is true', async () => {
+            const result = await plugin(testSchema, [], {
+                ...config,
+                fieldGeneration: {
+                    C: { enum: 'email' },
+                },
+                enumsAsTypes: true,
             });
             expect(result).toBeDefined();
 

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -181,6 +181,32 @@ it('should generate mock data with as-is enum values if enumValues is "keep"', a
     expect(result).toMatchSnapshot();
 });
 
+it('should generate mock data with enum values as string union type if enumsAsTypes is true', async () => {
+    const result = await plugin(testSchema, [], { enumsAsTypes: true });
+
+    expect(result).toBeDefined();
+    expect(result).not.toContain('Status.Online');
+    expect(result).toContain('Online');
+    expect(result).not.toContain('ABCStatus.hasXYZStatus');
+    expect(result).toContain('HasXyzStatus');
+    expect(result).not.toContain('Prefixed_Enum.PREFIXED_VALUE');
+    expect(result).toContain('PrefixedValue');
+    expect(result).toMatchSnapshot();
+});
+
+it('should generate mock data with as-is enum values as string union type if enumsAsTypes is true and enumValues is "keep"', async () => {
+    const result = await plugin(testSchema, [], { enumsAsTypes: true, enumValues: 'keep' });
+
+    expect(result).toBeDefined();
+    expect(result).not.toContain('Status.Online');
+    expect(result).toContain('ONLINE');
+    expect(result).not.toContain('ABCStatus.hasXYZStatus');
+    expect(result).toContain('hasXYZStatus');
+    expect(result).not.toContain('Prefixed_Enum.PREFIXED_VALUE');
+    expect(result).toContain('PREFIXED_VALUE');
+    expect(result).toMatchSnapshot();
+});
+
 it('should generate mock data with PascalCase types and enums by default', async () => {
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts' });
 
@@ -406,6 +432,26 @@ it('should preserve underscores if transformUnderscore is false', async () => {
     );
     expect(result).toContain(
         "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.Prefixed_Value,",
+    );
+    expect(result).toMatchSnapshot();
+});
+
+it('should preserve underscores if transformUnderscore is false and enumsAsTypes is true', async () => {
+    const result = await plugin(testSchema, [], {
+        transformUnderscore: false,
+        typesFile: './types/graphql.ts',
+        enumsAsTypes: true,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toContain(
+        "import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, Mutation, Query } from './types/graphql';",
+    );
+    expect(result).toContain(
+        'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
+    );
+    expect(result).toContain(
+        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'Prefixed_Value',",
     );
     expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR adds support for `enumsAsTypes` when enums as TypeScript string union types are desired.

Relates to enhancement: #117