### PR TITLE
fix: enum values update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -273,11 +273,11 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
                             opts.typeNamesConvention,
                             opts.transformUnderscore,
                         );
-                        const enumConverter = createNameConverter(opts.enumValuesConvention, opts.transformUnderscore);
+                        const enumConverter = createNameConverter(opts.enumValuesConvention, !opts.enumsAsTypes);
                         const value = foundType.values ? foundType.values[0] : '';
                         return handleValueGeneration(opts, undefined, () =>
                             opts.enumsAsTypes
-                                ? `'${enumConverter(value)}'`
+                                ? `'${value}'`
                                 : `${typenameConverter(foundType.name, opts.enumsPrefix)}.${enumConverter(value)}`,
                         );
                     }

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1980,12 +1980,12 @@ export const aUser = (overrides?: Partial<User>): User => {
         creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'Online',
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'HasXyzStatus',
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'hasXYZStatus',
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PrefixedValue',
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',
     };
 };
 
@@ -2702,7 +2702,7 @@ export const aUser = (overrides?: Partial<User>): User => {
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.Prefixed_Value,
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,
     };
 };
 
@@ -2776,12 +2776,12 @@ export const aUser = (overrides?: Partial<User>): User => {
         creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'Online',
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'HasXyzStatus',
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'hasXYZStatus',
         scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'Prefixed_Value',
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',
     };
 };
 

--- a/tests/enumValues/__snapshots__/spec.ts.snap
+++ b/tests/enumValues/__snapshots__/spec.ts.snap
@@ -1,14 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`enumValues config having 'change-case-all#pascalCase' value should keep underscores if 'transformUnderscore' is false 1`] = `
+exports[`enumValues config having 'change-case-all#pascalCase' value should keep underscores for type name only if 'transformUnderscore' is false 1`] = `
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum._Id,
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum.Id,
         pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PascalCase,
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.Snake_Case,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.Screaming_Snake_Case,
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SnakeCase,
+        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.ScreamingSnakeCase,
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCase_WithUnderscore.OtherSnakeCase,
     };
 };
 "
@@ -18,11 +19,12 @@ exports[`enumValues config having 'change-case-all#pascalCase' value should keep
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_Id',
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_id',
         pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'CamelCase',
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'Snake_Case',
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'Screaming_Snake_Case',
+        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
+        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : 'other_snake_case',
     };
 };
 "
@@ -37,6 +39,7 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SnakeCase,
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.ScreamingSnakeCase,
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCaseWithUnderscore.OtherSnakeCase,
     };
 };
 "
@@ -51,6 +54,7 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CAMELCASE,
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SNAKE_CASE,
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCase_WithUnderscore.OTHER_SNAKE_CASE,
     };
 };
 "
@@ -60,11 +64,12 @@ exports[`enumValues config having 'change-case-all#upperCase' value should keep 
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_ID',
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PASCALCASE',
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'CAMELCASE',
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'SNAKE_CASE',
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_id',
+        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
+        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : 'other_snake_case',
     };
 };
 "
@@ -79,12 +84,13 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CAMELCASE,
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SNAKE_CASE,
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCaseWithUnderscore.OTHER_SNAKE_CASE,
     };
 };
 "
 `;
 
-exports[`enumValues config having 'keep' value should have no effect if 'transformUnderscore' is false 1`] = `
+exports[`enumValues config having 'keep' value should have effect on enum type only if 'transformUnderscore' is false 1`] = `
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
@@ -93,6 +99,7 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.camelCase,
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.snake_case,
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCase_WithUnderscore.other_snake_case,
     };
 };
 "
@@ -107,6 +114,7 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : 'other_snake_case',
     };
 };
 "
@@ -121,20 +129,22 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.camelCase,
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.snake_case,
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCaseWithUnderscore.other_snake_case,
     };
 };
 "
 `;
 
-exports[`enumValues config having default value should keep underscores if 'transformUnderscore' is false 1`] = `
+exports[`enumValues config having default value should keep underscores for enum type only if 'transformUnderscore' is false 1`] = `
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum._Id,
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum.Id,
         pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PascalCase,
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.Snake_Case,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.Screaming_Snake_Case,
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SnakeCase,
+        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.ScreamingSnakeCase,
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCase_WithUnderscore.OtherSnakeCase,
     };
 };
 "
@@ -144,11 +154,12 @@ exports[`enumValues config having default value should keep underscores if 'tran
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_Id',
+        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_id',
         pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'CamelCase',
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'Snake_Case',
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'Screaming_Snake_Case',
+        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
+        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
+        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : 'other_snake_case',
     };
 };
 "
@@ -163,6 +174,7 @@ export const aMyType = (overrides?: Partial<MyType>): MyType => {
         camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
         snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SnakeCase,
         screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.ScreamingSnakeCase,
+        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCaseWithUnderscore.OtherSnakeCase,
     };
 };
 "

--- a/tests/enumValues/schema.ts
+++ b/tests/enumValues/schema.ts
@@ -21,11 +21,16 @@ export default buildSchema(/* GraphQL */ `
         SCREAMING_SNAKE_CASE
     }
 
+    enum PascalCase_WithUnderscore {
+        other_snake_case
+    }
+
     type MyType {
         underscoreEnum: UnderscoreEnum!
         pascalCaseEnum: PascalCaseEnum!
         camelCaseEnum: CamelCaseEnum!
         snakeCaseEnum: SnakeCaseEnum!
         screamingSnakeCaseEnum: ScreamingSnakeCaseEnum!
+        pascalCase_withUnderscore: PascalCase_WithUnderscore!
     }
 `);

--- a/tests/enumValues/spec.ts
+++ b/tests/enumValues/spec.ts
@@ -14,10 +14,11 @@ describe('enumValues config', () => {
             expect(result).toContain('CamelCaseEnum.camelCase');
             expect(result).toContain('SnakeCaseEnum.snake_case');
             expect(result).toContain('ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE');
+            expect(result).toContain('PascalCaseWithUnderscore.other_snake_case');
             expect(result).toMatchSnapshot();
         });
 
-        it(`should have no effect if 'transformUnderscore' is false`, async () => {
+        it(`should have effect on enum type only if 'transformUnderscore' is false`, async () => {
             const result = await plugin(enumSchema, [], {
                 enumValues: 'keep',
                 transformUnderscore: false,
@@ -29,6 +30,7 @@ describe('enumValues config', () => {
             expect(result).toContain('CamelCaseEnum.camelCase');
             expect(result).toContain('SnakeCaseEnum.snake_case');
             expect(result).toContain('ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE');
+            expect(result).toContain('PascalCase_WithUnderscore.other_snake_case');
             expect(result).toMatchSnapshot();
         });
 
@@ -45,6 +47,7 @@ describe('enumValues config', () => {
             expect(result).toContain('camelCase');
             expect(result).toContain('snake_case');
             expect(result).toContain('SCREAMING_SNAKE_CASE');
+            expect(result).toContain('other_snake_case');
             expect(result).toMatchSnapshot();
         });
     });
@@ -59,20 +62,22 @@ describe('enumValues config', () => {
             expect(result).toContain('CamelCaseEnum.CamelCase');
             expect(result).toContain('SnakeCaseEnum.SnakeCase');
             expect(result).toContain('ScreamingSnakeCaseEnum.ScreamingSnakeCase');
+            expect(result).toContain('PascalCaseWithUnderscore.OtherSnakeCase');
             expect(result).toMatchSnapshot();
         });
 
-        it(`should keep underscores if 'transformUnderscore' is false`, async () => {
+        it(`should keep underscores for enum type only if 'transformUnderscore' is false`, async () => {
             const result = await plugin(enumSchema, [], {
                 transformUnderscore: false,
             });
 
             expect(result).toBeDefined();
-            expect(result).toContain('UnderscoreEnum._Id');
+            expect(result).toContain('UnderscoreEnum.Id');
             expect(result).toContain('PascalCaseEnum.PascalCase');
             expect(result).toContain('CamelCaseEnum.CamelCase');
-            expect(result).toContain('SnakeCaseEnum.Snake_Case');
-            expect(result).toContain('ScreamingSnakeCaseEnum.Screaming_Snake_Case');
+            expect(result).toContain('SnakeCaseEnum.SnakeCase');
+            expect(result).toContain('ScreamingSnakeCaseEnum.ScreamingSnakeCase');
+            expect(result).toContain('PascalCase_WithUnderscore.OtherSnakeCase');
             expect(result).toMatchSnapshot();
         });
 
@@ -83,11 +88,12 @@ describe('enumValues config', () => {
             });
 
             expect(result).toBeDefined();
-            expect(result).toContain('_Id');
+            expect(result).toContain('_id');
             expect(result).toContain('PascalCase');
-            expect(result).toContain('CamelCase');
-            expect(result).toContain('Snake_Case');
-            expect(result).toContain('Screaming_Snake_Case');
+            expect(result).toContain('camelCase');
+            expect(result).toContain('snake_case');
+            expect(result).toContain('SCREAMING_SNAKE_CASE');
+            expect(result).toContain('other_snake_case');
             expect(result).toMatchSnapshot();
         });
     });
@@ -104,21 +110,23 @@ describe('enumValues config', () => {
             expect(result).toContain('CamelCaseEnum.CamelCase');
             expect(result).toContain('SnakeCaseEnum.SnakeCase');
             expect(result).toContain('ScreamingSnakeCaseEnum.ScreamingSnakeCase');
+            expect(result).toContain('PascalCaseWithUnderscore.OtherSnakeCase');
             expect(result).toMatchSnapshot();
         });
 
-        it(`should keep underscores if 'transformUnderscore' is false`, async () => {
+        it(`should keep underscores for type name only if 'transformUnderscore' is false`, async () => {
             const result = await plugin(enumSchema, [], {
                 enumValues: 'change-case-all#pascalCase',
                 transformUnderscore: false,
             });
 
             expect(result).toBeDefined();
-            expect(result).toContain('UnderscoreEnum._Id');
+            expect(result).toContain('UnderscoreEnum.Id');
             expect(result).toContain('PascalCaseEnum.PascalCase');
             expect(result).toContain('CamelCaseEnum.CamelCase');
-            expect(result).toContain('SnakeCaseEnum.Snake_Case');
-            expect(result).toContain('ScreamingSnakeCaseEnum.Screaming_Snake_Case');
+            expect(result).toContain('SnakeCaseEnum.SnakeCase');
+            expect(result).toContain('ScreamingSnakeCaseEnum.ScreamingSnakeCase');
+            expect(result).toContain('PascalCase_WithUnderscore.OtherSnakeCase');
             expect(result).toMatchSnapshot();
         });
 
@@ -130,11 +138,12 @@ describe('enumValues config', () => {
             });
 
             expect(result).toBeDefined();
-            expect(result).toContain('_Id');
+            expect(result).toContain('_id');
             expect(result).toContain('PascalCase');
-            expect(result).toContain('CamelCase');
-            expect(result).toContain('Snake_Case');
-            expect(result).toContain('Screaming_Snake_Case');
+            expect(result).toContain('camelCase');
+            expect(result).toContain('snake_case');
+            expect(result).toContain('SCREAMING_SNAKE_CASE');
+            expect(result).toContain('other_snake_case');
             expect(result).toMatchSnapshot();
         });
     });
@@ -151,6 +160,7 @@ describe('enumValues config', () => {
             expect(result).toContain('CamelCaseEnum.CAMELCASE');
             expect(result).toContain('SnakeCaseEnum.SNAKE_CASE');
             expect(result).toContain('ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE');
+            expect(result).toContain('PascalCaseWithUnderscore.OTHER_SNAKE_CASE');
             expect(result).toMatchSnapshot();
         });
 
@@ -167,6 +177,7 @@ describe('enumValues config', () => {
             expect(result).toContain('CamelCaseEnum.CAMELCASE');
             expect(result).toContain('SnakeCaseEnum.SNAKE_CASE');
             expect(result).toContain('ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE');
+            expect(result).toContain('PascalCase_WithUnderscore.OTHER_SNAKE_CASE');
             expect(result).toMatchSnapshot();
         });
 
@@ -179,11 +190,12 @@ describe('enumValues config', () => {
 
             expect(result).toBeDefined();
             expect(result).toBeDefined();
-            expect(result).toContain('_ID');
-            expect(result).toContain('PASCALCASE');
-            expect(result).toContain('CAMELCASE');
-            expect(result).toContain('SNAKE_CASE');
+            expect(result).toContain('_id');
+            expect(result).toContain('PascalCase');
+            expect(result).toContain('camelCase');
+            expect(result).toContain('snake_case');
             expect(result).toContain('SCREAMING_SNAKE_CASE');
+            expect(result).toContain('other_snake_case');
             expect(result).toMatchSnapshot();
         });
     });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -186,11 +186,11 @@ it('should generate mock data with enum values as string union type if enumsAsTy
 
     expect(result).toBeDefined();
     expect(result).not.toContain('Status.Online');
-    expect(result).toContain('Online');
+    expect(result).toContain('ONLINE');
     expect(result).not.toContain('ABCStatus.hasXYZStatus');
-    expect(result).toContain('HasXyzStatus');
+    expect(result).toContain('hasXYZStatus');
     expect(result).not.toContain('Prefixed_Enum.PREFIXED_VALUE');
-    expect(result).toContain('PrefixedValue');
+    expect(result).toContain('PREFIXED_VALUE');
     expect(result).toMatchSnapshot();
 });
 
@@ -431,7 +431,7 @@ it('should preserve underscores if transformUnderscore is false', async () => {
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
     );
     expect(result).toContain(
-        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.Prefixed_Value,",
+        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,",
     );
     expect(result).toMatchSnapshot();
 });
@@ -451,7 +451,7 @@ it('should preserve underscores if transformUnderscore is false and enumsAsTypes
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
     );
     expect(result).toContain(
-        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'Prefixed_Value',",
+        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',",
     );
     expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
Update enum values generation when it contains underscores to match Typescript generator
- Will use `transformUnderscore` config for enum type name only
- Enum keys underscores are always transformed, whatever the config from `transformUnderscore`

Update generation when `enumsAsTypes` is `true`:
- We need to keep the value as is because it's the string value to be sent