### PR TITLE
Use spread operator to override values (fixes #114)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -429,6 +429,7 @@ export const ${toMockName(
     relationshipsToOmit.add('${casedName}');
     return {${typename}
 ${fields}
+        ...overrides,
     };
 };`;
     } else {
@@ -440,6 +441,7 @@ export const ${toMockName(
         )} = (overrides?: Partial<${casedNameWithPrefix}>): ${typenameReturnType}${casedNameWithPrefix} => {
     return {${typename}
 ${fields}
+        ...overrides,
     };
 };`;
     }
@@ -656,7 +658,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                         nonNull: false,
                     });
 
-                    return `        ${fieldName}: overrides && overrides.hasOwnProperty('${fieldName}') ? overrides.${fieldName}! : ${value},`;
+                    return `        ${fieldName}: ${value},`;
                 },
             };
         },
@@ -692,7 +694,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                                       nonNull: false,
                                   });
 
-                                  return `        ${field.name.value}: overrides && overrides.hasOwnProperty('${field.name.value}') ? overrides.${field.name.value}! : ${value},`;
+                                  return `        ${field.name.value}: ${value},`;
                               })
                               .join('\n')
                         : '';

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -4,76 +4,86 @@ exports[`defaults all nullable fields to null when defaultNullableToNull is set 
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : null,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : null,
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : null,
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : null,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: null,
+        status: Status.Online,
+        customStatus: null,
+        scalarValue: 'neque',
+        camelCaseThing: null,
+        unionThing: null,
+        prefixedEnum: null,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: null,
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : null,
+        stringList: ['voluptatem'],
+        nullableStringList: null,
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : null,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: null,
+        avatar: null,
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : null,
+        updateUser: null,
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -83,76 +93,86 @@ exports[`overriding works as expected when defaultNullableToNull is true 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : someAvatar,
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'abc',
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : null,
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : null,
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : null,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: someAvatar,
+        status: Status.Online,
+        customStatus: 'abc',
+        scalarValue: 'neque',
+        camelCaseThing: null,
+        unionThing: null,
+        prefixedEnum: null,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: null,
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['abc'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['abc'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : null,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: null,
+        avatar: null,
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : null,
+        updateUser: null,
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -162,76 +182,86 @@ exports[`should add custom prefix if the \`prefix\` config option is specified 1
 "
 export const mockAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const mockUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : mockCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : mockAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: mockAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: mockCamelCaseThing(),
+        unionThing: mockAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const mockWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: mockAvatar(),
+        ...overrides,
     };
 };
 
 export const mockCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const mockPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const mockAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const mockListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const mockUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: mockAvatar(),
+        ...overrides,
     };
 };
 
 export const mockMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : mockUser(),
+        updateUser: mockUser(),
+        ...overrides,
     };
 };
 
 export const mockQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : mockUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : mockPrefixedResponse(),
+        user: mockUser(),
+        prefixed_query: mockPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -241,76 +271,86 @@ exports[`should add enumsPrefix to all enums when option is specified 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Api.Status.Online,
+        customStatus: Api.AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: Api.PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -321,76 +361,86 @@ exports[`should add enumsPrefix to imports 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Api.Status.Online,
+        customStatus: Api.AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: Api.PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -401,76 +451,86 @@ exports[`should add typesPrefix and enumsPrefix to imports 1`] = `
 
 export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<Api.User>): Api.User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : Api.AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Api.PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Api.Status.Online,
+        customStatus: Api.AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: Api.PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>): Api.PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Api.Mutation>): Api.Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Api.Query>): Api.Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -480,76 +540,86 @@ exports[`should add typesPrefix to all types when option is specified 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<Api.User>): Api.User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>): Api.PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Api.Mutation>): Api.Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Api.Query>): Api.Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -560,76 +630,86 @@ exports[`should add typesPrefix to imports 1`] = `
 
 export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<Api.User>): Api.User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<Api.PrefixedResponse>): Api.PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<Api.AbcType>): Api.AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Api.Mutation>): Api.Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Api.Query>): Api.Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -639,76 +719,86 @@ exports[`should correctly generate the \`casual\` data for a function with argum
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: '1977-06-26',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -718,76 +808,86 @@ exports[`should correctly generate the \`casual\` data for a function with one a
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : '1977-06-26',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: '1977-06-26',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -797,76 +897,86 @@ exports[`should correctly generate the \`casual\` data for a non-string scalar m
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,98,185],
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: [41,98,185],
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -876,76 +986,86 @@ exports[`should correctly generate the \`casual\` data for a scalar mapping of t
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohamed.Nader@Kiehn.io',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'Mohamed.Nader@Kiehn.io',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -955,76 +1075,86 @@ exports[`should correctly use custom generator as default value 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : myValueGenerator(),
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: myValueGenerator(),
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1037,76 +1167,86 @@ casual.seed(0);
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : casual.word,
+        id: casual.uuid,
+        url: casual.word,
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : new Date(casual.unix_time).toISOString(),
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : casual.word,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : casual.word,
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: casual.uuid,
+        creationDate: new Date(casual.unix_time).toISOString(),
+        login: casual.word,
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: casual.word,
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: casual.uuid,
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
+        id: casual.uuid,
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : casual.word,
+        ping: casual.word,
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : casual.word,
+        abc: casual.word,
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [casual.word],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : [casual.word],
+        stringList: [casual.word],
+        nullableStringList: [casual.word],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : casual.word,
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: casual.uuid,
+        login: casual.word,
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 
@@ -1121,76 +1261,86 @@ faker.seed(0);
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : faker.lorem.word(),
+        id: faker.datatype.uuid(),
+        url: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : faker.date.past(1, new Date(2022, 0)).toISOString(),
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : faker.lorem.word(),
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : faker.lorem.word(),
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: faker.datatype.uuid(),
+        creationDate: faker.date.past(1, new Date(2022, 0)).toISOString(),
+        login: faker.lorem.word(),
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: faker.lorem.word(),
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: faker.datatype.uuid(),
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
+        id: faker.datatype.uuid(),
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : faker.lorem.word(),
+        ping: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : faker.lorem.word(),
+        abc: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [faker.lorem.word()],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : [faker.lorem.word()],
+        stringList: [faker.lorem.word()],
+        nullableStringList: [faker.lorem.word()],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : faker.lorem.word(),
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: faker.datatype.uuid(),
+        login: faker.lorem.word(),
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 
@@ -1202,76 +1352,86 @@ exports[`should generate mock data functions 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1281,76 +1441,86 @@ exports[`should generate mock data functions with casual 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1361,76 +1531,86 @@ exports[`should generate mock data functions with external types file import 1`]
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1440,76 +1620,86 @@ exports[`should generate mock data functions with faker 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-bc38-ef1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '1550ff93-cd31-49b4-bc38-ef1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-9a7d-c13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'b5756f00-51a6-422a-9a7d-c13ee6a63750',
+        creationDate: '2021-06-27T14:29:24.774Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-8230-d4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '99f515e7-21e0-461d-8230-d4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-900f-beee5ee7fd42',
+        id: '245b9cf9-10fa-4974-900f-beee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-9e5f-14155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'eos',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '0d6a9360-d92b-4660-9e5f-14155047bddc',
+        login: 'eos',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1519,76 +1709,86 @@ exports[`should generate mock data functions with scalars 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1598,76 +1798,86 @@ exports[`should generate mock data with PascalCase enum values by default 1`] = 
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1677,76 +1887,86 @@ exports[`should generate mock data with PascalCase enum values if enumValues is 
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1756,76 +1976,86 @@ exports[`should generate mock data with PascalCase enum values if typeNames is "
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1836,76 +2066,86 @@ exports[`should generate mock data with PascalCase types and enums by default 1`
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1915,76 +2155,86 @@ exports[`should generate mock data with as-is enum values as string union type i
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'hasXYZStatus',
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: 'ONLINE',
+        customStatus: 'hasXYZStatus',
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: 'PREFIXED_VALUE',
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -1994,76 +2244,86 @@ exports[`should generate mock data with as-is enum values if enumValues is "keep
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.hasXYZStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.ONLINE,
+        customStatus: AbcStatus.hasXYZStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PREFIXED_VALUE,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2073,76 +2333,86 @@ exports[`should generate mock data with as-is types and enums if typeNames is "k
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : acamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: ABCStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: acamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: Prefixed_Enum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const acamelCaseThing = (overrides?: Partial<camelCaseThing>): camelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anABCType = (overrides?: Partial<ABCType>): ABCType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response(),
+        user: aUser(),
+        prefixed_query: aPrefixed_Response(),
+        ...overrides,
     };
 };
 "
@@ -2152,76 +2422,86 @@ exports[`should generate mock data with enum values as string union type if enum
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'hasXYZStatus',
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: 'ONLINE',
+        customStatus: 'hasXYZStatus',
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: 'PREFIXED_VALUE',
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2232,84 +2512,94 @@ exports[`should generate mock data with typename if addTypename is true 1`] = `
 export const anAvatar = (overrides?: Partial<Avatar>): { __typename: 'Avatar' } & Avatar => {
     return {
         __typename: 'Avatar',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): { __typename: 'User' } & User => {
     return {
         __typename: 'User',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): { __typename: 'WithAvatar' } & WithAvatar => {
     return {
         __typename: 'WithAvatar',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): { __typename: 'camelCaseThing' } & CamelCaseThing => {
     return {
         __typename: 'camelCaseThing',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): { __typename: 'Prefixed_Response' } & PrefixedResponse => {
     return {
         __typename: 'Prefixed_Response',
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): { __typename: 'ABCType' } & AbcType => {
     return {
         __typename: 'ABCType',
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): { __typename: 'ListType' } & ListType => {
     return {
         __typename: 'ListType',
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): { __typename: 'Mutation' } & Mutation => {
     return {
         __typename: 'Mutation',
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): { __typename: 'Query' } & Query => {
     return {
         __typename: 'Query',
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2319,76 +2609,86 @@ exports[`should generate mock data with upperCase enum values if enumValues is "
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HASXYZSTATUS,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PREFIXED_VALUE,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.ONLINE,
+        customStatus: AbcStatus.HASXYZSTATUS,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PREFIXED_VALUE,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2398,76 +2698,86 @@ exports[`should generate mock data with upperCase types and enums if typeNames i
 "
 export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUSER = (overrides?: Partial<USER>): USER => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAVATAR(),
+        status: STATUS.Online,
+        customStatus: ABCSTATUS.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCAMELCASETHING(),
+        unionThing: anAVATAR(),
+        prefixedEnum: PREFIXED_ENUM.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>): WITHAVATAR => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAVATAR(),
+        ...overrides,
     };
 };
 
 export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>): CAMELCASETHING => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>): PREFIXED_RESPONSE => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aLISTTYPE = (overrides?: Partial<LISTTYPE>): LISTTYPE => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>): UPDATEUSERINPUT => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAVATAR(),
+        ...overrides,
     };
 };
 
 export const aMUTATION = (overrides?: Partial<MUTATION>): MUTATION => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER(),
+        updateUser: aUSER(),
+        ...overrides,
     };
 };
 
 export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUSER(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPREFIXED_RESPONSE(),
+        user: aUSER(),
+        prefixed_query: aPREFIXED_RESPONSE(),
+        ...overrides,
     };
 };
 "
@@ -2478,76 +2788,86 @@ exports[`should generate mock data with upperCase types and imports if typeNames
 
 export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUSER = (overrides?: Partial<USER>): USER => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ABCSTATUS.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCAMELCASETHING(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAVATAR(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PREFIXED_ENUM.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAVATAR(),
+        status: STATUS.Online,
+        customStatus: ABCSTATUS.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCAMELCASETHING(),
+        unionThing: anAVATAR(),
+        prefixedEnum: PREFIXED_ENUM.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>): WITHAVATAR => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAVATAR(),
+        ...overrides,
     };
 };
 
 export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>): CAMELCASETHING => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPREFIXED_RESPONSE = (overrides?: Partial<PREFIXED_RESPONSE>): PREFIXED_RESPONSE => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anABCTYPE = (overrides?: Partial<ABCTYPE>): ABCTYPE => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aLISTTYPE = (overrides?: Partial<LISTTYPE>): LISTTYPE => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>): UPDATEUSERINPUT => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAVATAR(),
+        ...overrides,
     };
 };
 
 export const aMUTATION = (overrides?: Partial<MUTATION>): MUTATION => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER(),
+        updateUser: aUSER(),
+        ...overrides,
     };
 };
 
 export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUSER(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPREFIXED_RESPONSE(),
+        user: aUSER(),
+        prefixed_query: aPREFIXED_RESPONSE(),
+        ...overrides,
     };
 };
 "
@@ -2558,76 +2878,86 @@ exports[`should generate multiple list elements 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id', 'soluta', 'quis'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['soluta', 'deserunt', 'ut'],
+        stringList: ['id', 'soluta', 'quis'],
+        nullableStringList: ['soluta', 'deserunt', 'ut'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2638,76 +2968,86 @@ exports[`should generate no list elements when listElementCount is 0 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : [],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : [],
+        stringList: [],
+        nullableStringList: [],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2718,76 +3058,86 @@ exports[`should generate single list element 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2798,76 +3148,86 @@ exports[`should not merge imports into one if enumsPrefix does not contain dots 
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : ApiStatus.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : ApiAbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : ApiPrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: ApiStatus.Online,
+        customStatus: ApiAbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: ApiPrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2878,76 +3238,86 @@ exports[`should not merge imports into one if typesPrefix does not contain dots 
 
 export const anAvatar = (overrides?: Partial<ApiAvatar>): ApiAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<ApiUser>): ApiUser => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<ApiWithAvatar>): ApiWithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<ApiCamelCaseThing>): ApiCamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixedResponse = (overrides?: Partial<ApiPrefixedResponse>): ApiPrefixedResponse => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<ApiAbcType>): ApiAbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ApiListType>): ApiListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<ApiUpdateUserInput>): ApiUpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<ApiMutation>): ApiMutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<ApiQuery>): ApiQuery => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
+        user: aUser(),
+        prefixed_query: aPrefixedResponse(),
+        ...overrides,
     };
 };
 "
@@ -2958,76 +3328,86 @@ exports[`should preserve underscores if transformUnderscore is false 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: Prefixed_Enum.PrefixedValue,
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response(),
+        user: aUser(),
+        prefixed_query: aPrefixed_Response(),
+        ...overrides,
     };
 };
 "
@@ -3038,76 +3418,86 @@ exports[`should preserve underscores if transformUnderscore is false and enumsAs
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'hasXYZStatus',
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: anAvatar(),
+        status: 'ONLINE',
+        customStatus: 'hasXYZStatus',
+        scalarValue: 'neque',
+        camelCaseThing: aCamelCaseThing(),
+        unionThing: anAvatar(),
+        prefixedEnum: 'PREFIXED_VALUE',
+        ...overrides,
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
 export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
 export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
 export const aListType = (overrides?: Partial<ListType>): ListType => {
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: anAvatar(),
+        ...overrides,
     };
 };
 
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
+        updateUser: aUser(),
+        ...overrides,
     };
 };
 
 export const aQuery = (overrides?: Partial<Query>): Query => {
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixed_Response(),
+        user: aUser(),
+        prefixed_query: aPrefixed_Response(),
+        ...overrides,
     };
 };
 "
@@ -3119,8 +3509,9 @@ export const anAvatar = (overrides?: Partial<Avatar>, _relationshipsToOmit: Set<
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('Avatar');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
-        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'aliquid',
+        id: '0550ff93-dd31-49b4-8c38-ff1cb68bdc38',
+        url: 'aliquid',
+        ...overrides,
     };
 };
 
@@ -3128,16 +3519,17 @@ export const aUser = (overrides?: Partial<User>, _relationshipsToOmit: Set<strin
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('User');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '1970-01-09T16:33:21.532Z',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'libero',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
-        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
-        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',
-        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : relationshipsToOmit.has('CamelCaseThing') ? {} as CamelCaseThing : aCamelCaseThing({}, relationshipsToOmit),
-        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
-        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+        id: 'a5756f00-41a6-422a-8a7d-d13ee6a63750',
+        creationDate: '1970-01-09T16:33:21.532Z',
+        login: 'libero',
+        avatar: relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        status: Status.Online,
+        customStatus: AbcStatus.HasXyzStatus,
+        scalarValue: 'neque',
+        camelCaseThing: relationshipsToOmit.has('CamelCaseThing') ? {} as CamelCaseThing : aCamelCaseThing({}, relationshipsToOmit),
+        unionThing: relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        prefixedEnum: PrefixedEnum.PrefixedValue,
+        ...overrides,
     };
 };
 
@@ -3145,8 +3537,9 @@ export const aWithAvatar = (overrides?: Partial<WithAvatar>, _relationshipsToOmi
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('WithAvatar');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        id: '89f515e7-31e0-461d-a230-c4c7f4dafc5c',
+        avatar: relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        ...overrides,
     };
 };
 
@@ -3154,7 +3547,8 @@ export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _relationsh
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('CamelCaseThing');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        id: '345b9cf9-00fa-4974-800f-aeee5ee7fd42',
+        ...overrides,
     };
 };
 
@@ -3162,7 +3556,8 @@ export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _relati
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('PrefixedResponse');
     return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'sunt',
+        ping: 'sunt',
+        ...overrides,
     };
 };
 
@@ -3170,7 +3565,8 @@ export const anAbcType = (overrides?: Partial<AbcType>, _relationshipsToOmit: Se
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('AbcType');
     return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'sit',
+        abc: 'sit',
+        ...overrides,
     };
 };
 
@@ -3178,8 +3574,9 @@ export const aListType = (overrides?: Partial<ListType>, _relationshipsToOmit: S
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('ListType');
     return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['eum'],
+        stringList: ['voluptatem'],
+        nullableStringList: ['eum'],
+        ...overrides,
     };
 };
 
@@ -3187,9 +3584,10 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _relatio
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('UpdateUserInput');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1d6a9360-c92b-4660-8e5f-04155047bddc',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'qui',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        id: '1d6a9360-c92b-4660-8e5f-04155047bddc',
+        login: 'qui',
+        avatar: relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        ...overrides,
     };
 };
 
@@ -3197,7 +3595,8 @@ export const aMutation = (overrides?: Partial<Mutation>, _relationshipsToOmit: S
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('Mutation');
     return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : relationshipsToOmit.has('User') ? {} as User : aUser({}, relationshipsToOmit),
+        updateUser: relationshipsToOmit.has('User') ? {} as User : aUser({}, relationshipsToOmit),
+        ...overrides,
     };
 };
 
@@ -3205,8 +3604,9 @@ export const aQuery = (overrides?: Partial<Query>, _relationshipsToOmit: Set<str
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('Query');
     return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : relationshipsToOmit.has('User') ? {} as User : aUser({}, relationshipsToOmit),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : relationshipsToOmit.has('PrefixedResponse') ? {} as PrefixedResponse : aPrefixedResponse({}, relationshipsToOmit),
+        user: relationshipsToOmit.has('User') ? {} as User : aUser({}, relationshipsToOmit),
+        prefixed_query: relationshipsToOmit.has('PrefixedResponse') ? {} as PrefixedResponse : aPrefixedResponse({}, relationshipsToOmit),
+        ...overrides,
     };
 };
 "

--- a/tests/enumValues/__snapshots__/spec.ts.snap
+++ b/tests/enumValues/__snapshots__/spec.ts.snap
@@ -4,12 +4,13 @@ exports[`enumValues config having 'change-case-all#pascalCase' value should keep
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum.Id,
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PascalCase,
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SnakeCase,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.ScreamingSnakeCase,
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCase_WithUnderscore.OtherSnakeCase,
+        underscoreEnum: UnderscoreEnum.Id,
+        pascalCaseEnum: PascalCaseEnum.PascalCase,
+        camelCaseEnum: CamelCaseEnum.CamelCase,
+        snakeCaseEnum: SnakeCaseEnum.SnakeCase,
+        screamingSnakeCaseEnum: ScreamingSnakeCaseEnum.ScreamingSnakeCase,
+        pascalCase_withUnderscore: PascalCase_WithUnderscore.OtherSnakeCase,
+        ...overrides,
     };
 };
 "
@@ -19,12 +20,13 @@ exports[`enumValues config having 'change-case-all#pascalCase' value should keep
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_id',
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : 'other_snake_case',
+        underscoreEnum: '_id',
+        pascalCaseEnum: 'PascalCase',
+        camelCaseEnum: 'camelCase',
+        snakeCaseEnum: 'snake_case',
+        screamingSnakeCaseEnum: 'SCREAMING_SNAKE_CASE',
+        pascalCase_withUnderscore: 'other_snake_case',
+        ...overrides,
     };
 };
 "
@@ -34,12 +36,13 @@ exports[`enumValues config having 'change-case-all#pascalCase' value should upda
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum.Id,
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PascalCase,
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SnakeCase,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.ScreamingSnakeCase,
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCaseWithUnderscore.OtherSnakeCase,
+        underscoreEnum: UnderscoreEnum.Id,
+        pascalCaseEnum: PascalCaseEnum.PascalCase,
+        camelCaseEnum: CamelCaseEnum.CamelCase,
+        snakeCaseEnum: SnakeCaseEnum.SnakeCase,
+        screamingSnakeCaseEnum: ScreamingSnakeCaseEnum.ScreamingSnakeCase,
+        pascalCase_withUnderscore: PascalCaseWithUnderscore.OtherSnakeCase,
+        ...overrides,
     };
 };
 "
@@ -49,12 +52,13 @@ exports[`enumValues config having 'change-case-all#upperCase' value should keep 
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum._ID,
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PASCALCASE,
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CAMELCASE,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SNAKE_CASE,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCase_WithUnderscore.OTHER_SNAKE_CASE,
+        underscoreEnum: UnderscoreEnum._ID,
+        pascalCaseEnum: PascalCaseEnum.PASCALCASE,
+        camelCaseEnum: CamelCaseEnum.CAMELCASE,
+        snakeCaseEnum: SnakeCaseEnum.SNAKE_CASE,
+        screamingSnakeCaseEnum: ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+        pascalCase_withUnderscore: PascalCase_WithUnderscore.OTHER_SNAKE_CASE,
+        ...overrides,
     };
 };
 "
@@ -64,12 +68,13 @@ exports[`enumValues config having 'change-case-all#upperCase' value should keep 
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_id',
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : 'other_snake_case',
+        underscoreEnum: '_id',
+        pascalCaseEnum: 'PascalCase',
+        camelCaseEnum: 'camelCase',
+        snakeCaseEnum: 'snake_case',
+        screamingSnakeCaseEnum: 'SCREAMING_SNAKE_CASE',
+        pascalCase_withUnderscore: 'other_snake_case',
+        ...overrides,
     };
 };
 "
@@ -79,12 +84,13 @@ exports[`enumValues config having 'change-case-all#upperCase' value should updat
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum._ID,
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PASCALCASE,
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CAMELCASE,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SNAKE_CASE,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCaseWithUnderscore.OTHER_SNAKE_CASE,
+        underscoreEnum: UnderscoreEnum._ID,
+        pascalCaseEnum: PascalCaseEnum.PASCALCASE,
+        camelCaseEnum: CamelCaseEnum.CAMELCASE,
+        snakeCaseEnum: SnakeCaseEnum.SNAKE_CASE,
+        screamingSnakeCaseEnum: ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+        pascalCase_withUnderscore: PascalCaseWithUnderscore.OTHER_SNAKE_CASE,
+        ...overrides,
     };
 };
 "
@@ -94,12 +100,13 @@ exports[`enumValues config having 'keep' value should have effect on enum type o
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum._id,
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PascalCase,
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.camelCase,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.snake_case,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCase_WithUnderscore.other_snake_case,
+        underscoreEnum: UnderscoreEnum._id,
+        pascalCaseEnum: PascalCaseEnum.PascalCase,
+        camelCaseEnum: CamelCaseEnum.camelCase,
+        snakeCaseEnum: SnakeCaseEnum.snake_case,
+        screamingSnakeCaseEnum: ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+        pascalCase_withUnderscore: PascalCase_WithUnderscore.other_snake_case,
+        ...overrides,
     };
 };
 "
@@ -109,12 +116,13 @@ exports[`enumValues config having 'keep' value should have no effect if 'transfo
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_id',
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : 'other_snake_case',
+        underscoreEnum: '_id',
+        pascalCaseEnum: 'PascalCase',
+        camelCaseEnum: 'camelCase',
+        snakeCaseEnum: 'snake_case',
+        screamingSnakeCaseEnum: 'SCREAMING_SNAKE_CASE',
+        pascalCase_withUnderscore: 'other_snake_case',
+        ...overrides,
     };
 };
 "
@@ -124,12 +132,13 @@ exports[`enumValues config having 'keep' value should keep case 1`] = `
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum._id,
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PascalCase,
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.camelCase,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.snake_case,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCaseWithUnderscore.other_snake_case,
+        underscoreEnum: UnderscoreEnum._id,
+        pascalCaseEnum: PascalCaseEnum.PascalCase,
+        camelCaseEnum: CamelCaseEnum.camelCase,
+        snakeCaseEnum: SnakeCaseEnum.snake_case,
+        screamingSnakeCaseEnum: ScreamingSnakeCaseEnum.SCREAMING_SNAKE_CASE,
+        pascalCase_withUnderscore: PascalCaseWithUnderscore.other_snake_case,
+        ...overrides,
     };
 };
 "
@@ -139,12 +148,13 @@ exports[`enumValues config having default value should keep underscores for enum
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum.Id,
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PascalCase,
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SnakeCase,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.ScreamingSnakeCase,
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCase_WithUnderscore.OtherSnakeCase,
+        underscoreEnum: UnderscoreEnum.Id,
+        pascalCaseEnum: PascalCaseEnum.PascalCase,
+        camelCaseEnum: CamelCaseEnum.CamelCase,
+        snakeCaseEnum: SnakeCaseEnum.SnakeCase,
+        screamingSnakeCaseEnum: ScreamingSnakeCaseEnum.ScreamingSnakeCase,
+        pascalCase_withUnderscore: PascalCase_WithUnderscore.OtherSnakeCase,
+        ...overrides,
     };
 };
 "
@@ -154,12 +164,13 @@ exports[`enumValues config having default value should keep underscores if 'tran
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : '_id',
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : 'PascalCase',
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : 'camelCase',
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : 'snake_case',
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : 'SCREAMING_SNAKE_CASE',
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : 'other_snake_case',
+        underscoreEnum: '_id',
+        pascalCaseEnum: 'PascalCase',
+        camelCaseEnum: 'camelCase',
+        snakeCaseEnum: 'snake_case',
+        screamingSnakeCaseEnum: 'SCREAMING_SNAKE_CASE',
+        pascalCase_withUnderscore: 'other_snake_case',
+        ...overrides,
     };
 };
 "
@@ -169,12 +180,13 @@ exports[`enumValues config having default value should update case in pascal cas
 "
 export const aMyType = (overrides?: Partial<MyType>): MyType => {
     return {
-        underscoreEnum: overrides && overrides.hasOwnProperty('underscoreEnum') ? overrides.underscoreEnum! : UnderscoreEnum.Id,
-        pascalCaseEnum: overrides && overrides.hasOwnProperty('pascalCaseEnum') ? overrides.pascalCaseEnum! : PascalCaseEnum.PascalCase,
-        camelCaseEnum: overrides && overrides.hasOwnProperty('camelCaseEnum') ? overrides.camelCaseEnum! : CamelCaseEnum.CamelCase,
-        snakeCaseEnum: overrides && overrides.hasOwnProperty('snakeCaseEnum') ? overrides.snakeCaseEnum! : SnakeCaseEnum.SnakeCase,
-        screamingSnakeCaseEnum: overrides && overrides.hasOwnProperty('screamingSnakeCaseEnum') ? overrides.screamingSnakeCaseEnum! : ScreamingSnakeCaseEnum.ScreamingSnakeCase,
-        pascalCase_withUnderscore: overrides && overrides.hasOwnProperty('pascalCase_withUnderscore') ? overrides.pascalCase_withUnderscore! : PascalCaseWithUnderscore.OtherSnakeCase,
+        underscoreEnum: UnderscoreEnum.Id,
+        pascalCaseEnum: PascalCaseEnum.PascalCase,
+        camelCaseEnum: CamelCaseEnum.CamelCase,
+        snakeCaseEnum: SnakeCaseEnum.SnakeCase,
+        screamingSnakeCaseEnum: ScreamingSnakeCaseEnum.ScreamingSnakeCase,
+        pascalCase_withUnderscore: PascalCaseWithUnderscore.OtherSnakeCase,
+        ...overrides,
     };
 };
 "

--- a/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
+++ b/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
@@ -7,31 +7,34 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual['integer'](...[1,100]).toFixed(),
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual['integer'](...[1,100]).toFixed(),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: casual['word'],
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -52,31 +55,34 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual['integer'](...[1,100]).toFixed(...[3]),
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual['integer'](...[1,100]).toFixed(...[3]),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: casual['word'],
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -97,31 +103,34 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual['integer'](...[1,100]).toFixed(...[3]),
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual['integer'](...[1,100]).toFixed(...[3]),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: casual['word'],
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -142,31 +151,34 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual['integer'](...[1,100]),
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual['integer'](...[1,100]),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: casual['word'],
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -187,31 +199,34 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['email'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['email'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['email'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['email'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: casual['word'],
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -232,31 +247,34 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['email'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['email'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: casual['word'],
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -277,31 +295,34 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : casual['email'],
+        id: datatype.integer,
+        str: casual['word'],
+        enum: casual['email'],
+        ...overrides,
     };
 };
 
@@ -367,31 +388,34 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['email'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['email'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: casual['word'],
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -409,31 +433,34 @@ exports[`per type field generation with casual without dynamic values can accept
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '39',
+        id: datatype.integer,
+        str: 'ea',
+        email: 'vero',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: '39',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'quibusdam',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -449,31 +476,34 @@ exports[`per type field generation with casual without dynamic values can accept
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '39.000',
+        id: datatype.integer,
+        str: 'ea',
+        email: 'vero',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: '39.000',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'quibusdam',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -489,31 +519,34 @@ exports[`per type field generation with casual without dynamic values can accept
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '39.000',
+        id: datatype.integer,
+        str: 'ea',
+        email: 'vero',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: '39.000',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'quibusdam',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -529,31 +562,34 @@ exports[`per type field generation with casual without dynamic values can accept
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 39,
+        id: datatype.integer,
+        str: 'ea',
+        email: 'vero',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: 39,
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'quibusdam',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -569,31 +605,34 @@ exports[`per type field generation with casual without dynamic values can apply 
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'Schuppe.Demario@yahoo.com',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'vel',
+        id: datatype.integer,
+        str: 'ea',
+        email: 'Schuppe.Demario@yahoo.com',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: 'vel',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'Molly.Wuckert@gmail.com',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'Molly.Wuckert@gmail.com',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -609,31 +648,34 @@ exports[`per type field generation with casual without dynamic values can overwr
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'Schuppe.Demario@yahoo.com',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'vel',
+        id: datatype.integer,
+        str: 'ea',
+        email: 'Schuppe.Demario@yahoo.com',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: 'vel',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'quibusdam',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -649,31 +691,34 @@ exports[`per type field generation with casual without dynamic values can overwr
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'vel',
+        id: datatype.integer,
+        str: 'ea',
+        email: 'vero',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: 'vel',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'quibusdam',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'Roosevelt.Oberbrunner@gmail.com',
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: 'Roosevelt.Oberbrunner@gmail.com',
+        ...overrides,
     };
 };
 
@@ -729,31 +774,34 @@ exports[`per type field generation with casual without dynamic values uses per f
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'Schuppe.Demario@yahoo.com',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'vel',
+        id: datatype.integer,
+        str: 'ea',
+        email: 'Schuppe.Demario@yahoo.com',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: 'vel',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'quibusdam',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -772,31 +820,34 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker['date']['recent'](...[10]).toLocaleDateString(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker['date']['recent'](...[10]).toLocaleDateString(),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -817,31 +868,34 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker['date']['recent'](...[10]).toLocaleDateString(...[\\"en-GB\\"]),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker['date']['recent'](...[10]).toLocaleDateString(...[\\"en-GB\\"]),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -862,31 +916,34 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker['date']['recent'](...[10]).toLocaleDateString(...[\\"en-GB\\"]),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker['date']['recent'](...[10]).toLocaleDateString(...[\\"en-GB\\"]),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -907,31 +964,34 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker['date']['recent'](...[10]),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker['date']['recent'](...[10]),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -952,31 +1012,34 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['internet']['email'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['internet']['email'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['internet']['email'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['internet']['email'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1095,31 +1158,34 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['internet']['email'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['past'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['internet']['email'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['past'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1140,31 +1206,34 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : faker['helpers']['arrayElement'](...[[\\"active\\",\\"disabled\\"]]),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: faker['helpers']['arrayElement'](...[[\\"active\\",\\"disabled\\"]]),
+        ...overrides,
     };
 };
 
@@ -1230,31 +1299,34 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['internet']['email'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['internet']['email'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1272,31 +1344,34 @@ exports[`per type field generation with faker without dynamic values can accept 
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '1/1/2022',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: '1/1/2022',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: 1,
+        str: 'A sentence',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1312,31 +1387,34 @@ exports[`per type field generation with faker without dynamic values can accept 
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '01/01/2022',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: '01/01/2022',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: 1,
+        str: 'A sentence',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1352,31 +1430,34 @@ exports[`per type field generation with faker without dynamic values can accept 
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : \\"2022-01-01T00:00:00.000Z\\",
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: \\"2022-01-01T00:00:00.000Z\\",
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: 1,
+        str: 'A sentence',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1392,31 +1473,34 @@ exports[`per type field generation with faker without dynamic values can apply g
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'my@email.com',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'my@email.com',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'my@email.com',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'my@email.com',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: 1,
+        str: 'A sentence',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1432,31 +1516,34 @@ exports[`per type field generation with faker without dynamic values can overwri
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'my@email.com',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2020-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'my@email.com',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2020-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: 1,
+        str: 'A sentence',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1472,31 +1559,34 @@ exports[`per type field generation with faker without dynamic values can overwri
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'my@email.com',
+        id: 1,
+        str: 'A sentence',
+        enum: 'my@email.com',
+        ...overrides,
     };
 };
 
@@ -1552,31 +1642,34 @@ exports[`per type field generation with faker without dynamic values uses per fi
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'my@email.com',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'my@email.com',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: 1,
+        str: 'A sentence',
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 

--- a/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
+++ b/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
@@ -40,7 +40,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -88,7 +89,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -136,7 +138,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -184,7 +187,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -232,7 +236,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -280,7 +285,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -328,7 +334,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -343,37 +350,41 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+        id: datatype.integer,
+        str: casual['word'],
+        email: casual['word'],
+        date: casual['date'](),
+        overriddenDate: casual['date'](),
+        dateTime: casual.word,
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['word'],
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : casual['email'],
+        id: datatype.integer,
+        str: casual['word'],
+        enum: casual['email'],
+        ...overrides,
     };
 };
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -421,7 +432,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -466,7 +478,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -509,7 +522,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -552,7 +566,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -595,7 +610,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -638,7 +654,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -681,7 +698,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -724,7 +742,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -734,37 +753,41 @@ exports[`per type field generation with casual without dynamic values can overwr
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'vel',
+        id: datatype.integer,
+        str: 'ea',
+        email: 'vero',
+        date: '2004-01-01',
+        overriddenDate: '1995-09-05',
+        dateTime: 'vel',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1980-12-10',
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '2014-12-19',
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+        id: datatype.integer,
+        str: 'consectetur',
+        email: 'quibusdam',
+        date: '1980-12-10',
+        overriddenDate: '2014-12-19',
+        dateTime: 'ut',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : datatype.integer,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'Roosevelt.Oberbrunner@gmail.com',
+        id: datatype.integer,
+        str: 'voluptas',
+        enum: 'Roosevelt.Oberbrunner@gmail.com',
+        ...overrides,
     };
 };
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -807,7 +830,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -853,7 +877,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -901,7 +926,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -949,7 +975,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -997,7 +1024,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -1045,7 +1073,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -1060,37 +1089,41 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : null,
+        nested: null,
+        ...overrides,
     };
 };
 
@@ -1107,12 +1140,13 @@ export const anA = (overrides?: Partial<A>, _relationshipsToOmit: Set<string> = 
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('A');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
@@ -1120,12 +1154,13 @@ export const aB = (overrides?: Partial<B>, _relationshipsToOmit: Set<string> = n
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('B');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
@@ -1133,9 +1168,10 @@ export const aC = (overrides?: Partial<C>, _relationshipsToOmit: Set<string> = n
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('C');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: EnumExample.Lorem,
+        ...overrides,
     };
 };
 
@@ -1143,7 +1179,8 @@ export const aD = (overrides?: Partial<D>, _relationshipsToOmit: Set<string> = n
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('D');
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : null,
+        nested: null,
+        ...overrides,
     };
 };
 
@@ -1191,7 +1228,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -1239,7 +1277,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -1254,37 +1293,41 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        email: faker['lorem']['sentence'](),
+        date: faker['date']['future'](),
+        overriddenDate: faker['date']['future'](),
+        dateTime: faker.lorem.word(),
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : faker['helpers']['arrayElement'](...[[\\"active\\",\\"disabled\\"]]),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        enum: faker['helpers']['arrayElement'](...[[\\"active\\",\\"disabled\\"]]),
+        ...overrides,
     };
 };
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -1332,7 +1375,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 
@@ -1377,7 +1421,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -1420,7 +1465,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -1463,7 +1509,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -1506,7 +1553,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -1549,7 +1597,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -1592,7 +1641,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -1602,37 +1652,41 @@ exports[`per type field generation with faker without dynamic values can overwri
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
-        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
-        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
-        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+        id: 1,
+        str: 'A sentence',
+        email: 'A sentence',
+        date: \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: 'Word',
+        ...overrides,
     };
 };
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
-        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'my@email.com',
+        id: 1,
+        str: 'A sentence',
+        enum: 'my@email.com',
+        ...overrides,
     };
 };
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "
@@ -1675,7 +1729,8 @@ export const aC = (overrides?: Partial<C>): C => {
 
 export const aD = (overrides?: Partial<D>): D => {
     return {
-        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+        nested: aC(),
+        ...overrides,
     };
 };
 "

--- a/tests/perTypeFieldGeneration/spec.ts
+++ b/tests/perTypeFieldGeneration/spec.ts
@@ -53,13 +53,9 @@ describe('per type field generation with faker', () => {
             expect(result).toBeDefined();
 
             // Custom generation in type A
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['internet']['email']()",
-            );
+            expect(result).toContain("email: faker['internet']['email']()");
             // Original generation in type B (unchanged)
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),",
-            );
+            expect(result).toContain("email: faker['lorem']['sentence'](),");
 
             expect(result).toMatchSnapshot();
         });
@@ -73,12 +69,8 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future']()",
-            );
-            expect(result).toContain(
-                "overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['past']()",
-            );
+            expect(result).toContain("date: faker['date']['future']()");
+            expect(result).toContain("overriddenDate: faker['date']['past']()");
 
             expect(result).toMatchSnapshot();
         });
@@ -121,9 +113,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                `enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : faker['helpers']['arrayElement'](...[["active","disabled"]]),`,
-            );
+            expect(result).toContain(`enum: faker['helpers']['arrayElement'](...[["active","disabled"]]),`);
 
             expect(result).toMatchSnapshot();
         });
@@ -156,11 +146,7 @@ describe('per type field generation with faker', () => {
             expect(result).toBeDefined();
 
             // Check both `email` fields are updated
-            expect(
-                String(result).match(
-                    /email: overrides && overrides.hasOwnProperty\('email'\) \? overrides.email! : faker\['internet']\['email']\(\)/g,
-                ).length,
-            ).toEqual(2);
+            expect(String(result).match(/email: faker\['internet']\['email']\(\)/g).length).toEqual(2);
             expect(result).toMatchSnapshot();
         });
 
@@ -178,9 +164,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker['date']['recent'](...[10])",
-            );
+            expect(result).toContain("dateTime: faker['date']['recent'](...[10])");
 
             expect(result).toMatchSnapshot();
         });
@@ -202,9 +186,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker['date']['recent'](...[10]).toLocaleDateString()",
-            );
+            expect(result).toContain("dateTime: faker['date']['recent'](...[10]).toLocaleDateString()");
 
             expect(result).toMatchSnapshot();
         });
@@ -227,9 +209,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker['date']['recent'](...[10]).toLocaleDateString(...[\"en-GB\"])",
-            );
+            expect(result).toContain("dateTime: faker['date']['recent'](...[10]).toLocaleDateString(...[\"en-GB\"])");
 
             expect(result).toMatchSnapshot();
         });
@@ -252,9 +232,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker['date']['recent'](...[10]).toLocaleDateString(...[\"en-GB\"])",
-            );
+            expect(result).toContain("dateTime: faker['date']['recent'](...[10]).toLocaleDateString(...[\"en-GB\"])");
 
             expect(result).toMatchSnapshot();
         });
@@ -275,13 +253,9 @@ describe('per type field generation with faker', () => {
             expect(result).toBeDefined();
 
             // Custom generation in type A
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'my@email.com'",
-            );
+            expect(result).toContain("email: 'my@email.com'");
             // Original generation in type B (unchanged)
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence",
-            );
+            expect(result).toContain("email: 'A sentence");
 
             expect(result).toMatchSnapshot();
         });
@@ -295,12 +269,8 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                'date: overrides && overrides.hasOwnProperty(\'date\') ? overrides.date! : "2050-01-01T00:00:00.000Z"',
-            );
-            expect(result).toContain(
-                'overriddenDate: overrides && overrides.hasOwnProperty(\'overriddenDate\') ? overrides.overriddenDate! : "2020-01-01T00:00:00.000Z"',
-            );
+            expect(result).toContain('date: "2050-01-01T00:00:00.000Z"');
+            expect(result).toContain('overriddenDate: "2020-01-01T00:00:00.000Z"');
 
             expect(result).toMatchSnapshot();
         });
@@ -314,9 +284,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'my@email.com'",
-            );
+            expect(result).toContain("enum: 'my@email.com'");
 
             expect(result).toMatchSnapshot();
         });
@@ -349,11 +317,7 @@ describe('per type field generation with faker', () => {
             expect(result).toBeDefined();
 
             // Check both `email` fields are updated
-            expect(
-                String(result).match(
-                    /email: overrides && overrides.hasOwnProperty\('email'\) \? overrides.email! : 'my@email.com'/g,
-                ).length,
-            ).toEqual(2);
+            expect(String(result).match(/email: 'my@email.com'/g).length).toEqual(2);
             expect(result).toMatchSnapshot();
         });
 
@@ -371,9 +335,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                'dateTime: overrides && overrides.hasOwnProperty(\'dateTime\') ? overrides.dateTime! : "2022-01-01T00:00:00.000Z"',
-            );
+            expect(result).toContain('dateTime: "2022-01-01T00:00:00.000Z"');
 
             expect(result).toMatchSnapshot();
         });
@@ -395,9 +357,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '1/1/2022'",
-            );
+            expect(result).toContain("dateTime: '1/1/2022'");
 
             expect(result).toMatchSnapshot();
         });
@@ -420,9 +380,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '01/01/2022'",
-            );
+            expect(result).toContain("dateTime: '01/01/2022'");
 
             expect(result).toMatchSnapshot();
         });
@@ -457,13 +415,9 @@ describe('per type field generation with casual', () => {
             expect(result).toBeDefined();
 
             // Custom generation in type A
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['email']",
-            );
+            expect(result).toContain("email: casual['email']");
             // Original generation in type B (unchanged)
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual['word'],",
-            );
+            expect(result).toContain("email: casual['word'],");
 
             expect(result).toMatchSnapshot();
         });
@@ -477,12 +431,8 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : casual['date']",
-            );
-            expect(result).toContain(
-                "overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : casual['date']()",
-            );
+            expect(result).toContain("date: casual['date']");
+            expect(result).toContain("overriddenDate: casual['date']()");
 
             expect(result).toMatchSnapshot();
         });
@@ -496,9 +446,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : casual['email'],",
-            );
+            expect(result).toContain("enum: casual['email'],");
 
             expect(result).toMatchSnapshot();
         });
@@ -531,11 +479,7 @@ describe('per type field generation with casual', () => {
             expect(result).toBeDefined();
 
             // Check both `email` fields are updated
-            expect(
-                String(result).match(
-                    /email: overrides && overrides.hasOwnProperty\('email'\) \? overrides.email! : casual\['email']/g,
-                ).length,
-            ).toEqual(2);
+            expect(String(result).match(/email: casual\['email']/g).length).toEqual(2);
             expect(result).toMatchSnapshot();
         });
 
@@ -553,9 +497,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual['integer'](...[1,100])",
-            );
+            expect(result).toContain("dateTime: casual['integer'](...[1,100])");
 
             expect(result).toMatchSnapshot();
         });
@@ -577,9 +519,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual['integer'](...[1,100]).toFixed()",
-            );
+            expect(result).toContain("dateTime: casual['integer'](...[1,100]).toFixed()");
 
             expect(result).toMatchSnapshot();
         });
@@ -602,9 +542,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual['integer'](...[1,100]).toFixed(...[3])",
-            );
+            expect(result).toContain("dateTime: casual['integer'](...[1,100]).toFixed(...[3])");
 
             expect(result).toMatchSnapshot();
         });
@@ -627,9 +565,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual['integer'](...[1,100]).toFixed(...[3])",
-            );
+            expect(result).toContain("dateTime: casual['integer'](...[1,100]).toFixed(...[3])");
 
             expect(result).toMatchSnapshot();
         });
@@ -650,13 +586,9 @@ describe('per type field generation with casual', () => {
             expect(result).toBeDefined();
 
             // Custom generation in type A
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'Schuppe.Demario@yahoo.com'",
-            );
+            expect(result).toContain("email: 'Schuppe.Demario@yahoo.com'");
             // Original generation in type B (unchanged)
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam'",
-            );
+            expect(result).toContain("email: 'quibusdam'");
 
             expect(result).toMatchSnapshot();
         });
@@ -670,12 +602,8 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '2004-01-01'",
-            );
-            expect(result).toContain(
-                "overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1995-09-05'",
-            );
+            expect(result).toContain("date: '2004-01-01'");
+            expect(result).toContain("overriddenDate: '1995-09-05'");
 
             expect(result).toMatchSnapshot();
         });
@@ -689,9 +617,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'Roosevelt.Oberbrunner@gmail.com'",
-            );
+            expect(result).toContain("enum: 'Roosevelt.Oberbrunner@gmail.com'");
 
             expect(result).toMatchSnapshot();
         });
@@ -724,12 +650,8 @@ describe('per type field generation with casual', () => {
             expect(result).toBeDefined();
 
             // Check both `email` fields are updated
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'Schuppe.Demario@yahoo.com'",
-            );
-            expect(result).toContain(
-                "email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'Molly.Wuckert@gmail.com'",
-            );
+            expect(result).toContain("email: 'Schuppe.Demario@yahoo.com'");
+            expect(result).toContain("email: 'Molly.Wuckert@gmail.com'");
             expect(result).toMatchSnapshot();
         });
 
@@ -747,9 +669,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 39",
-            );
+            expect(result).toContain('dateTime: 39');
 
             expect(result).toMatchSnapshot();
         });
@@ -771,9 +691,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '39'",
-            );
+            expect(result).toContain("dateTime: '39'");
 
             expect(result).toMatchSnapshot();
         });
@@ -796,9 +714,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '39.000'",
-            );
+            expect(result).toContain("dateTime: '39.000'");
 
             expect(result).toMatchSnapshot();
         });
@@ -821,9 +737,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : '39.000'",
-            );
+            expect(result).toContain("dateTime: '39.000'");
 
             expect(result).toMatchSnapshot();
         });

--- a/tests/perTypeFieldGeneration/spec.ts
+++ b/tests/perTypeFieldGeneration/spec.ts
@@ -84,7 +84,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain("overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : null");
+            expect(result).toContain('nested: null');
 
             expect(result).toMatchSnapshot();
         });
@@ -99,7 +99,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain("overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : null");
+            expect(result).toContain('nested: null');
 
             expect(result).toMatchSnapshot();
         });
@@ -128,9 +128,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                `enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : faker['helpers']['arrayElement'](...[["active","disabled"]]),`,
-            );
+            expect(result).toContain(`enum: faker['helpers']['arrayElement'](...[["active","disabled"]]),`);
 
             expect(result).toMatchSnapshot();
         });
@@ -299,9 +297,7 @@ describe('per type field generation with faker', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'my@email.com'",
-            );
+            expect(result).toContain("enum: 'my@email.com'");
 
             expect(result).toMatchSnapshot();
         });
@@ -461,9 +457,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : casual['email'],",
-            );
+            expect(result).toContain("enum: casual['email'],");
 
             expect(result).toMatchSnapshot();
         });
@@ -632,9 +626,7 @@ describe('per type field generation with casual', () => {
             });
             expect(result).toBeDefined();
 
-            expect(result).toContain(
-                "enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : 'Roosevelt.Oberbrunner@gmail.com'",
-            );
+            expect(result).toContain("enum: 'Roosevelt.Oberbrunner@gmail.com'");
 
             expect(result).toMatchSnapshot();
         });

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -4,18 +4,20 @@ exports[`should generate custom scalars for native and custom types using casual
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Kelly_Cremin@Turcotte.biz',
+        id: 82,
+        str: 'ea corrupti qui incidunt eius consequatur blanditiis',
+        obj: aB(),
+        anyObject: 'Kelly_Cremin@Turcotte.biz',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+        int: -93,
+        flt: -24.509902694262564,
+        bool: false,
+        ...overrides,
     };
 };
 "
@@ -25,18 +27,20 @@ exports[`should generate custom scalars for native and custom types using faker 
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Corrupti qui incidunt eius consequatur qui.',
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Orlando64@gmail.com',
+        id: 83,
+        str: 'Corrupti qui incidunt eius consequatur qui.',
+        obj: aB(),
+        anyObject: 'Orlando64@gmail.com',
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+        int: -93,
+        flt: -24.51,
+        bool: false,
+        ...overrides,
     };
 };
 "
@@ -49,18 +53,20 @@ casual.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual['integer'](...[1,100]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['string'],
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : casual['email'],
+        id: casual['integer'](...[1,100]),
+        str: casual['string'],
+        obj: aB(),
+        anyObject: casual['email'],
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : casual['integer'](...[-100,0]),
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : casual['double'](...[-100,0]),
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+        int: casual['integer'](...[-100,0]),
+        flt: casual['double'](...[-100,0]),
+        bool: false,
+        ...overrides,
     };
 };
 
@@ -75,18 +81,20 @@ faker.seed(0);
 
 export const anA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : faker['internet']['email'](),
+        id: faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: faker['lorem']['sentence'](),
+        obj: aB(),
+        anyObject: faker['internet']['email'](),
+        ...overrides,
     };
 };
 
 export const aB = (overrides?: Partial<B>): B => {
     return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : faker['datatype']['number'](...[{\\"min\\":-100,\\"max\\":0}]),
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : faker['datatype']['float'](...[{\\"min\\":-100,\\"max\\":0}]),
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+        int: faker['datatype']['number'](...[{\\"min\\":-100,\\"max\\":0}]),
+        flt: faker['datatype']['float'](...[{\\"min\\":-100,\\"max\\":0}]),
+        bool: false,
+        ...overrides,
     };
 };
 

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -25,23 +25,19 @@ it('should generate custom scalars for native and custom types using casual', as
     expect(result).toBeDefined();
 
     // String
-    expect(result).toContain(
-        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',",
-    );
+    expect(result).toContain("str: 'ea corrupti qui incidunt eius consequatur blanditiis',");
 
     // Float
-    expect(result).toContain(
-        "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,",
-    );
+    expect(result).toContain('flt: -24.509902694262564,');
 
     // ID
-    expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,");
+    expect(result).toContain('id: 82,');
 
     // Boolean
-    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+    expect(result).toContain('bool: false');
 
     // Int
-    expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
+    expect(result).toContain('int: -93,');
 
     expect(result).toMatchSnapshot();
 });
@@ -71,25 +67,19 @@ it('should generate dynamic custom scalars for native and custom types using cas
     expect(result).toBeDefined();
 
     // String
-    expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['string'],");
+    expect(result).toContain("str: casual['string'],");
 
     // Float
-    expect(result).toContain(
-        "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : casual['double'](...[-100,0]),",
-    );
+    expect(result).toContain("flt: casual['double'](...[-100,0]),");
 
     // ID
-    expect(result).toContain(
-        "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual['integer'](...[1,100]),",
-    );
+    expect(result).toContain("id: casual['integer'](...[1,100]),");
 
     // Boolean
-    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+    expect(result).toContain('bool: false');
 
     // Int
-    expect(result).toContain(
-        "int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : casual['integer'](...[-100,0]),",
-    );
+    expect(result).toContain("int: casual['integer'](...[-100,0]),");
 
     expect(result).toMatchSnapshot();
 });
@@ -119,21 +109,19 @@ it('should generate custom scalars for native and custom types using faker', asy
     expect(result).toBeDefined();
 
     // String
-    expect(result).toContain(
-        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Corrupti qui incidunt eius consequatur qui.',",
-    );
+    expect(result).toContain("str: 'Corrupti qui incidunt eius consequatur qui.',");
 
     // Float
-    expect(result).toContain("flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,");
+    expect(result).toContain('flt: -24.51,');
 
     // ID
-    expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,");
+    expect(result).toContain('id: 83,');
 
     // Boolean
-    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+    expect(result).toContain('bool: false');
 
     // Int
-    expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
+    expect(result).toContain('int: -93,');
 
     expect(result).toMatchSnapshot();
 });
@@ -164,27 +152,19 @@ it('should generate dynamic custom scalars for native and custom types using fak
     expect(result).toBeDefined();
 
     // String
-    expect(result).toContain(
-        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),",
-    );
+    expect(result).toContain("str: faker['lorem']['sentence'](),");
 
     // Float
-    expect(result).toContain(
-        "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : faker['datatype']['float'](...[{\"min\":-100,\"max\":0}]),",
-    );
+    expect(result).toContain('flt: faker[\'datatype\'][\'float\'](...[{"min":-100,"max":0}]),');
 
     // ID
-    expect(result).toContain(
-        "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\"min\":1,\"max\":100}]),",
-    );
+    expect(result).toContain('id: faker[\'datatype\'][\'number\'](...[{"min":1,"max":100}]),');
 
     // Boolean
-    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+    expect(result).toContain('bool: false');
 
     // Int
-    expect(result).toContain(
-        "int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : faker['datatype']['number'](...[{\"min\":-100,\"max\":0}]),",
-    );
+    expect(result).toContain('int: faker[\'datatype\'][\'number\'](...[{"min":-100,"max":0}]),');
 
     expect(result).toMatchSnapshot();
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -429,8 +429,7 @@ it('should preserve underscores if transformUnderscore is false', async () => {
     expect(result).toContain(
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
     );
-    expect(result).toContain('prefixedEnum: Prefixed_Enum.PrefixedValue,",
-    );
+    expect(result).toContain('prefixedEnum: Prefixed_Enum.PrefixedValue,');
     expect(result).toMatchSnapshot();
 });
 
@@ -448,8 +447,7 @@ it('should preserve underscores if transformUnderscore is false and enumsAsTypes
     expect(result).toContain(
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
     );
-    expect(result).toContain(
-        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',');
+    expect(result).toContain("prefixedEnum: 'PREFIXED_VALUE',");
     expect(result).toMatchSnapshot();
 });
 
@@ -481,9 +479,7 @@ it('should generate no list elements when listElementCount is 0', async () => {
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain(
-        "stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : []",
-    );
+    expect(result).toContain('stringList: []');
     expect(result).toMatchSnapshot();
 });
 
@@ -505,23 +501,13 @@ it('defaults all nullable fields to null when defaultNullableToNull is set', asy
     const result = await plugin(testSchema, [], { defaultNullableToNull: true });
 
     expect(result).toBeDefined();
-    expect(result).toContain(
-        "customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : null",
-    );
-    expect(result).toContain(
-        "camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : null",
-    );
-    expect(result).toContain(
-        "unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : null",
-    );
-    expect(result).toContain(
-        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : null",
-    );
-    expect(result).toContain("avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null");
-    expect(result).toContain("login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : null");
-    expect(result).toContain(
-        "nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : null",
-    );
+    expect(result).toContain('customStatus: null');
+    expect(result).toContain('camelCaseThing: null');
+    expect(result).toContain('unionThing: null');
+    expect(result).toContain('prefixedEnum: null');
+    expect(result).toContain('avatar: null');
+    expect(result).toContain('login: null');
+    expect(result).toContain('nullableStringList: null');
 
     expect(result).toMatchSnapshot();
 });
@@ -541,15 +527,9 @@ it('overriding works as expected when defaultNullableToNull is true', async () =
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain(
-        "customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : 'abc'",
-    );
-    expect(result).toContain(
-        "avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : someAvatar",
-    );
-    expect(result).toContain(
-        "nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['abc']",
-    );
+    expect(result).toContain("customStatus: 'abc'");
+    expect(result).toContain('avatar: someAvatar');
+    expect(result).toContain("nullableStringList: ['abc']");
 
     expect(result).toMatchSnapshot();
 });

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -110,9 +110,7 @@ it('should generate mock data functions with scalars', async () => {
     const result = await plugin(testSchema, [], {});
 
     expect(result).toBeDefined();
-    expect(result).toContain(
-        "scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'neque',",
-    );
+    expect(result).toContain("scalarValue: 'neque',");
     expect(result).toMatchSnapshot();
 });
 
@@ -431,8 +429,7 @@ it('should preserve underscores if transformUnderscore is false', async () => {
     expect(result).toContain(
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
     );
-    expect(result).toContain(
-        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : Prefixed_Enum.PrefixedValue,",
+    expect(result).toContain('prefixedEnum: Prefixed_Enum.PrefixedValue,",
     );
     expect(result).toMatchSnapshot();
 });
@@ -452,8 +449,7 @@ it('should preserve underscores if transformUnderscore is false and enumsAsTypes
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
     );
     expect(result).toContain(
-        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',",
-    );
+        "prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : 'PREFIXED_VALUE',');
     expect(result).toMatchSnapshot();
 });
 
@@ -463,9 +459,7 @@ it('should generate single list element', async () => {
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain(
-        "stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['voluptatem']",
-    );
+    expect(result).toContain("stringList: ['voluptatem']");
     expect(result).toMatchSnapshot();
 });
 
@@ -476,9 +470,7 @@ it('should generate multiple list elements', async () => {
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain(
-        "stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['id', 'soluta', 'quis']",
-    );
+    expect(result).toContain("stringList: ['id', 'soluta', 'quis']");
     expect(result).toMatchSnapshot();
 });
 

--- a/tests/useImplementingTypes/__snapshots__/spec.ts.snap
+++ b/tests/useImplementingTypes/__snapshots__/spec.ts.snap
@@ -4,60 +4,68 @@ exports[`should support useImplementingTypes 1`] = `
 "
 export const mockAConfig = (overrides?: Partial<AConfig>): AConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
+        testTypes: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockField = (overrides?: Partial<Field>): Field => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
+        testTypes: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockAction = (overrides?: Partial<Action>): Action => {
     return {
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : [TestObj.Test],
+        action: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'cae147b0-1c04-459e-82db-624dd87433b4',
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : mockB(),
-        config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : mockTestAConfig() || mockTestTwoAConfig(),
-        configArray: overrides && overrides.hasOwnProperty('configArray') ? overrides.configArray! : [mockTestAConfig() || mockTestTwoAConfig()],
-        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : mockTestTwoAConfig(),
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : mockTestAction(),
+        id: 'cae147b0-1c04-459e-82db-624dd87433b4',
+        str: 'ea',
+        obj: mockB(),
+        config: mockTestAConfig() || mockTestTwoAConfig(),
+        configArray: [mockTestAConfig() || mockTestTwoAConfig()],
+        field: mockTestTwoAConfig(),
+        action: mockTestAction(),
+        ...overrides,
     };
 };
 
 export const mockB = (overrides?: Partial<B>): B => {
     return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : 696,
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : 7.55,
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+        int: 696,
+        flt: 7.55,
+        bool: false,
+        ...overrides,
     };
 };
 
 export const mockTestAConfig = (overrides?: Partial<TestAConfig>): TestAConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
-        active: overrides && overrides.hasOwnProperty('active') ? overrides.active! : true,
+        testTypes: [TestObj.Test],
+        active: true,
+        ...overrides,
     };
 };
 
 export const mockTestTwoAConfig = (overrides?: Partial<TestTwoAConfig>): TestTwoAConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
-        username: overrides && overrides.hasOwnProperty('username') ? overrides.username! : 'et',
+        testTypes: [TestObj.Test],
+        username: 'et',
+        ...overrides,
     };
 };
 
 export const mockTestAction = (overrides?: Partial<TestAction>): TestAction => {
     return {
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : [TestObj.Test],
-        createdAt: overrides && overrides.hasOwnProperty('createdAt') ? overrides.createdAt! : 'voluptate',
+        action: [TestObj.Test],
+        createdAt: 'voluptate',
+        ...overrides,
     };
 };
 "
@@ -67,60 +75,68 @@ exports[`shouldn't support useImplementingTypes 1`] = `
 "
 export const mockAConfig = (overrides?: Partial<AConfig>): AConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
+        testTypes: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockField = (overrides?: Partial<Field>): Field => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
+        testTypes: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockAction = (overrides?: Partial<Action>): Action => {
     return {
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : [TestObj.Test],
+        action: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'cae147b0-1c04-459e-82db-624dd87433b4',
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : mockB(),
-        config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : mockAConfig(),
-        configArray: overrides && overrides.hasOwnProperty('configArray') ? overrides.configArray! : [mockAConfig()],
-        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : mockField(),
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : mockAction(),
+        id: 'cae147b0-1c04-459e-82db-624dd87433b4',
+        str: 'ea',
+        obj: mockB(),
+        config: mockAConfig(),
+        configArray: [mockAConfig()],
+        field: mockField(),
+        action: mockAction(),
+        ...overrides,
     };
 };
 
 export const mockB = (overrides?: Partial<B>): B => {
     return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : 696,
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : 7.55,
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+        int: 696,
+        flt: 7.55,
+        bool: false,
+        ...overrides,
     };
 };
 
 export const mockTestAConfig = (overrides?: Partial<TestAConfig>): TestAConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
-        active: overrides && overrides.hasOwnProperty('active') ? overrides.active! : true,
+        testTypes: [TestObj.Test],
+        active: true,
+        ...overrides,
     };
 };
 
 export const mockTestTwoAConfig = (overrides?: Partial<TestTwoAConfig>): TestTwoAConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
-        username: overrides && overrides.hasOwnProperty('username') ? overrides.username! : 'et',
+        testTypes: [TestObj.Test],
+        username: 'et',
+        ...overrides,
     };
 };
 
 export const mockTestAction = (overrides?: Partial<TestAction>): TestAction => {
     return {
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : [TestObj.Test],
-        createdAt: overrides && overrides.hasOwnProperty('createdAt') ? overrides.createdAt! : 'voluptate',
+        action: [TestObj.Test],
+        createdAt: 'voluptate',
+        ...overrides,
     };
 };
 "
@@ -130,60 +146,68 @@ exports[`support useImplementingTypes with fieldGeneration prop 1`] = `
 "
 export const mockAConfig = (overrides?: Partial<AConfig>): AConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
+        testTypes: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockField = (overrides?: Partial<Field>): Field => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
+        testTypes: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockAction = (overrides?: Partial<Action>): Action => {
     return {
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : [TestObj.Test],
+        action: [TestObj.Test],
+        ...overrides,
     };
 };
 
 export const mockA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'cae147b0-1c04-459e-82db-624dd87433b4',
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : mockB(),
-        config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : 'Karelle_Kassulke@Carolyne.io',
-        configArray: overrides && overrides.hasOwnProperty('configArray') ? overrides.configArray! : [mockTestAConfig() || mockTestTwoAConfig()],
-        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : mockTestTwoAConfig(),
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : mockTestAction(),
+        id: 'cae147b0-1c04-459e-82db-624dd87433b4',
+        str: 'ea',
+        obj: mockB(),
+        config: 'Karelle_Kassulke@Carolyne.io',
+        configArray: [mockTestAConfig() || mockTestTwoAConfig()],
+        field: mockTestTwoAConfig(),
+        action: mockTestAction(),
+        ...overrides,
     };
 };
 
 export const mockB = (overrides?: Partial<B>): B => {
     return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : 696,
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : 7.55,
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+        int: 696,
+        flt: 7.55,
+        bool: false,
+        ...overrides,
     };
 };
 
 export const mockTestAConfig = (overrides?: Partial<TestAConfig>): TestAConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
-        active: overrides && overrides.hasOwnProperty('active') ? overrides.active! : true,
+        testTypes: [TestObj.Test],
+        active: true,
+        ...overrides,
     };
 };
 
 export const mockTestTwoAConfig = (overrides?: Partial<TestTwoAConfig>): TestTwoAConfig => {
     return {
-        testTypes: overrides && overrides.hasOwnProperty('testTypes') ? overrides.testTypes! : [TestObj.Test],
-        username: overrides && overrides.hasOwnProperty('username') ? overrides.username! : 'et',
+        testTypes: [TestObj.Test],
+        username: 'et',
+        ...overrides,
     };
 };
 
 export const mockTestAction = (overrides?: Partial<TestAction>): TestAction => {
     return {
-        action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : [TestObj.Test],
-        createdAt: overrides && overrides.hasOwnProperty('createdAt') ? overrides.createdAt! : 'voluptate',
+        action: [TestObj.Test],
+        createdAt: 'voluptate',
+        ...overrides,
     };
 };
 "

--- a/tests/useImplementingTypes/spec.ts
+++ b/tests/useImplementingTypes/spec.ts
@@ -6,21 +6,13 @@ it('should support useImplementingTypes', async () => {
 
     expect(result).toBeDefined();
 
-    expect(result).toContain(
-        "config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : mockTestAConfig() || mockTestTwoAConfig(),",
-    );
+    expect(result).toContain('config: mockTestAConfig() || mockTestTwoAConfig(),');
 
-    expect(result).toContain(
-        "configArray: overrides && overrides.hasOwnProperty('configArray') ? overrides.configArray! : [mockTestAConfig() || mockTestTwoAConfig()],",
-    );
+    expect(result).toContain('configArray: [mockTestAConfig() || mockTestTwoAConfig()],');
 
-    expect(result).toContain(
-        "field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : mockTestTwoAConfig(),",
-    );
+    expect(result).toContain('field: mockTestTwoAConfig(),');
 
-    expect(result).toContain(
-        "action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : mockTestAction(),",
-    );
+    expect(result).toContain('action: mockTestAction(),');
     expect(result).toMatchSnapshot();
 });
 
@@ -29,9 +21,7 @@ it(`shouldn't support useImplementingTypes`, async () => {
 
     expect(result).toBeDefined();
 
-    expect(result).toContain(
-        "config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : mockAConfig(),",
-    );
+    expect(result).toContain('config: mockAConfig(),');
 
     expect(result).toMatchSnapshot();
 });
@@ -46,13 +36,9 @@ it(`support useImplementingTypes with fieldGeneration prop`, async () => {
     });
     expect(result).toBeDefined();
 
-    expect(result).toContain(
-        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Krystel.Farrell@Frederique.biz'",
-    );
+    expect(result).toContain("str: 'Krystel.Farrell@Frederique.biz'");
 
-    expect(result).toContain(
-        "config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : mockTestAConfig() || mockTestTwoAConfig(),",
-    );
+    expect(result).toContain('config: mockTestAConfig() || mockTestTwoAConfig(),');
 
     result = await plugin(testSchema, [], {
         prefix: 'mock',
@@ -63,11 +49,9 @@ it(`support useImplementingTypes with fieldGeneration prop`, async () => {
     });
     expect(result).toBeDefined();
 
-    expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea'");
+    expect(result).toContain("str: 'ea'");
 
-    expect(result).toContain(
-        "config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : 'Karelle_Kassulke@Carolyne.io',",
-    );
+    expect(result).toContain("config: 'Karelle_Kassulke@Carolyne.io',");
 
     expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR implements a new way of generating mock types. Instead of relying on checking overrides for a specific property name, we instead just spread any provided overrides over the `key:value` object of field to value.

In my opinion this has a couple of benefits:

- Easier to read. There's less going on per line - it's clear what the generated value is.
- Eslint may encourage you to not use `.hasOwnProperty`
- Don't need to use `!` to satisfy TypeScript

I've updated all tests, and looking through the snapshots looks positive!