### PR TITLE
Adds support for multiple generators per scalar/field, chosen randomly

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ If all choices the same weight, they are equally likely to be chosen; the defaul
 Providing three generator options with weights of 2, 1, and 1, for instance, means the first will be chosen half the time and the others one-quarter of the time each.
 The `weight` is ignored if only a single generator option is provided.
 
+### defineWeightedChoice (`boolean`, defaultValue: `false`)
+
+Provides a default implementation of the `weightedChoice` function, used when choosing a random generator if multiple options are provided for a field.
+This function is not used in the default scenario where only a single generator is provided for any given field.
+Instead of using the default, you may provide your own implementation with the signature `(weights: number[], random: () => number)`.
+
 ### `GeneratorOptions` type
 
 This type is used in `scalars` and `fieldGeneration` options.
@@ -221,6 +227,7 @@ You can specify an array of generator options, and one will be chosen at random.
 By default, the choices are equally likely.
 You can specify a `weight` option to change how likely a given generator is to be chosen; if not specified, a weight of 1 is assumed.
 Both the shortcut string-only and full `GeneratorOptions` object are supported if multiple generators are supplied.
+When providing multiple options, you must either specify `defineWeightedChoice: true` in your config or provide your own implementation of the `weightedhChoice` function.
 
 Examples using **casual**
 

--- a/README.md
+++ b/README.md
@@ -206,9 +206,21 @@ For detailed configuration options, see [GeneratorOptions](#generatoroptions-typ
 Select a library to generate mock values. The default is [casual](https://github.com/boo1ean/casual), Other options include [faker](https://github.com/faker-js/faker).
 casual dependents on Node API and cannot be executed in a browser. faker is useful when you want to use a mock function with the dynamicValues option enabled in the browser.
 
+### weight (`number`, defaultValue: `1`)
+
+If multiple generator options are provided for a scalar or field, specifies the relative chances of a generator being chosen at random.
+If all choices the same weight, they are equally likely to be chosen; the default is 1.
+Providing three generator options with weights of 2, 1, and 1, for instance, means the first will be chosen half the time and the others one-quarter of the time each.
+The `weight` is ignored if only a single generator option is provided.
+
 ### `GeneratorOptions` type
 
 This type is used in `scalars` and `fieldGeneration` options.
+
+You can specify an array of generator options, and one will be chosen at random.
+By default, the choices are equally likely.
+You can specify a `weight` option to change how likely a given generator is to be chosen; if not specified, a weight of 1 is assumed.
+Both the shortcut string-only and full `GeneratorOptions` object are supported if multiple generators are supplied.
 
 Examples using **casual**
 
@@ -314,6 +326,25 @@ fieldName: # gets translated to casual.date().toLocaleDateString('en_GB)
 ```yaml
 # gets translated as is
 fieldName: arrayBufferGenerator()
+```
+
+**Multiple generators**
+
+```yaml
+fieldName: # will be null 3/4 of the time, contain the output of lorem.paragraphs() the other 1/4
+  - generator: 'null'
+    weight: 3
+  - lorem.paragraphs
+```
+
+which could also be written as:
+
+```yaml
+fieldName: # will be null 3/4 of the time, contain the output of lorem.paragraphs() the other 1/4
+  - 'null'
+  - 'null'
+  - 'null'
+  - lorem.paragraphs
 ```
 
 ## Examples of usage

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ fieldName: arrayBufferGenerator()
 **Multiple generators**
 
 ```yaml
-fieldName: # will be null 3/4 of the time, contain the output of lorem.paragraphs() the other 1/4
+fieldName: # will be null 3/4 of the time, contain the output of faker.lorem.paragraphs() the other 1/4
   - generator: 'null'
     weight: 3
   - lorem.paragraphs
@@ -347,7 +347,7 @@ fieldName: # will be null 3/4 of the time, contain the output of lorem.paragraph
 which could also be written as:
 
 ```yaml
-fieldName: # will be null 3/4 of the time, contain the output of lorem.paragraphs() the other 1/4
+fieldName: # will be null 3/4 of the time, contain the output of faker.lorem.paragraphs() the other 1/4
   - 'null'
   - 'null'
   - 'null'

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ const hashedString = (value: string) => {
     return hash;
 };
 
-const getGeneratorDefinitions = (value: GeneratorOptions): GeneratorDefinition[] | undefined => {
+const getGeneratorDefinition = (value: GeneratorOptions): GeneratorDefinition[] | undefined => {
     if (value === undefined) {
         return undefined;
     }
@@ -283,12 +283,12 @@ const handleValueGeneration = (
     if (opts.fieldGeneration) {
         // Check for a specific generation for the type & field
         if (opts.typeName in opts.fieldGeneration && opts.fieldName in opts.fieldGeneration[opts.typeName]) {
-            const generatorDefinitions = getGeneratorDefinitions(opts.fieldGeneration[opts.typeName][opts.fieldName]);
+            const generatorDefinitions = getGeneratorDefinition(opts.fieldGeneration[opts.typeName][opts.fieldName]);
             return getCustomValue(generatorDefinitions, opts);
         }
         // Check for a general field generation definition
         if ('_all' in opts.fieldGeneration && opts.fieldName in opts.fieldGeneration['_all']) {
-            const generatorDefinitions = getGeneratorDefinitions(opts.fieldGeneration['_all'][opts.fieldName]);
+            const generatorDefinitions = getGeneratorDefinition(opts.fieldGeneration['_all'][opts.fieldName]);
             return getCustomValue(generatorDefinitions, opts);
         }
     }
@@ -326,23 +326,23 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
     const casedName = createNameConverter(opts.typeNamesConvention, opts.transformUnderscore)(name);
     switch (name) {
         case 'String': {
-            const customScalar = opts.customScalars ? getGeneratorDefinitions(opts.customScalars['String']) : null;
+            const customScalar = opts.customScalars ? getGeneratorDefinition(opts.customScalars['String']) : null;
             return handleValueGeneration(opts, customScalar, mockValueGenerator.word);
         }
         case 'Float': {
-            const customScalar = opts.customScalars ? getGeneratorDefinitions(opts.customScalars['Float']) : null;
+            const customScalar = opts.customScalars ? getGeneratorDefinition(opts.customScalars['Float']) : null;
             return handleValueGeneration(opts, customScalar, mockValueGenerator.float);
         }
         case 'ID': {
-            const customScalar = opts.customScalars ? getGeneratorDefinitions(opts.customScalars['ID']) : null;
+            const customScalar = opts.customScalars ? getGeneratorDefinition(opts.customScalars['ID']) : null;
             return handleValueGeneration(opts, customScalar, mockValueGenerator.uuid);
         }
         case 'Boolean': {
-            const customScalar = opts.customScalars ? getGeneratorDefinitions(opts.customScalars['Boolean']) : null;
+            const customScalar = opts.customScalars ? getGeneratorDefinition(opts.customScalars['Boolean']) : null;
             return handleValueGeneration(opts, customScalar, mockValueGenerator.boolean);
         }
         case 'Int': {
-            const customScalar = opts.customScalars ? getGeneratorDefinitions(opts.customScalars['Int']) : null;
+            const customScalar = opts.customScalars ? getGeneratorDefinition(opts.customScalars['Int']) : null;
             return handleValueGeneration(opts, customScalar, mockValueGenerator.integer);
         }
         default: {
@@ -377,7 +377,7 @@ const getNamedType = (opts: Options<NamedTypeNode>): string | number | boolean =
                         });
                     case 'scalar': {
                         const customScalar = opts.customScalars
-                            ? getGeneratorDefinitions(opts.customScalars[foundType.name])
+                            ? getGeneratorDefinition(opts.customScalars[foundType.name])
                             : null;
 
                         // it's a scalar, let's use a string as a value if there is no custom

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ const weightedChoice = (weights: number[], random: () => number) => {
 const getRandomFunctionDynamic = (opts: Options<NamedTypeNode>) => {
     switch (opts.generateLibrary) {
         case 'casual':
-            throw `Not implemented: ${opts.generateLibrary}`;
+            return 'casual.double(0, 1.0)';
         case 'faker':
             return 'faker.datatype.float({ max: 1.0 })';
         default:
@@ -239,7 +239,7 @@ const getRandomFunctionDynamic = (opts: Options<NamedTypeNode>) => {
 const getRandomFunction = (opts: Options<NamedTypeNode>) => {
     switch (opts.generateLibrary) {
         case 'casual':
-            throw `Not implemented: ${opts.generateLibrary}`;
+            return () => casual.double(0, 1.0);
         case 'faker':
             return () => faker.datatype.float({ max: 1.0 });
         default:

--- a/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
+++ b/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
@@ -1638,7 +1638,7 @@ exports[`per-type random generator using casual without dynamic values should ge
 export const anA = (overrides?: Partial<A>): A => {
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'cae147b0-1c04-459e-82db-624dd87433b4',
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
         email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
         date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1970-01-13T10:02:01.054Z',
         overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1970-01-10T09:04:53.325Z',

--- a/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
+++ b/tests/perTypeFieldGeneration/__snapshots__/spec.ts.snap
@@ -1587,3 +1587,173 @@ export const aD = (overrides?: Partial<D>): D => {
 };
 "
 `;
+
+exports[`per-type random generator using casual with dynamic values should generate random fields using casual 1`] = `
+"import casual from 'casual';
+
+casual.seed(0);
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : [() => casual['string'], () => casual['word']][weightedChoice([1,1], () => casual.double(0, 1.0))](),
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual.word,
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : new Date(casual.unix_time).toISOString(),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : new Date(casual.unix_time).toISOString(),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual.word,
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : casual.word,
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : new Date(casual.unix_time).toISOString(),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : new Date(casual.unix_time).toISOString(),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : casual.word,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual.uuid,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual.word,
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
+export const aD = (overrides?: Partial<D>): D => {
+    return {
+        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+    };
+};
+
+export const seedMocks = (seed: number) => casual.seed(seed);
+"
+`;
+
+exports[`per-type random generator using casual without dynamic values should generate random fields using casual 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'cae147b0-1c04-459e-82db-624dd87433b4',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'vero',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1970-01-13T10:02:01.054Z',
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1970-01-10T09:04:53.325Z',
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'vel',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '2adf6f2a-dfd8-451a-bc13-cdc42cd4d792',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'consectetur',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'quibusdam',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : '1970-01-04T23:55:36.062Z',
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : '1970-01-17T10:09:47.625Z',
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'ut',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'd51e6316-92d8-4082-99dd-f8c5b2f9fb2a',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'voluptas',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
+export const aD = (overrides?: Partial<D>): D => {
+    return {
+        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+    };
+};
+"
+`;
+
+exports[`per-type random generator using faker with dynamic values should generate random fields using faker 1`] = `
+"import { faker } from '@faker-js/faker';
+
+faker.seed(0);
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : [() => faker['lorem']['sentence'](), () => faker['lorem']['word']()][weightedChoice([1,1], () => faker.datatype.float({ max: 1.0 }))](),
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : [() => faker['lorem']['word'](...[3]), () => faker['lorem']['sentence'](...[3])][weightedChoice([1,99], () => faker.datatype.float({ max: 1.0 }))](),
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : faker['lorem']['sentence'](),
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : faker['date']['future'](),
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : faker['date']['future'](),
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : faker.lorem.word(),
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['datatype']['number'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
+export const aD = (overrides?: Partial<D>): D => {
+    return {
+        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+    };
+};
+
+export const seedMocks = (seed: number) => faker.seed(seed);
+"
+`;
+
+exports[`per-type random generator using faker without dynamic values should generate random fields using faker 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Word',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        email: overrides && overrides.hasOwnProperty('email') ? overrides.email! : 'A sentence',
+        date: overrides && overrides.hasOwnProperty('date') ? overrides.date! : \\"2050-01-01T00:00:00.000Z\\",
+        overriddenDate: overrides && overrides.hasOwnProperty('overriddenDate') ? overrides.overriddenDate! : \\"2050-01-01T00:00:00.000Z\\",
+        dateTime: overrides && overrides.hasOwnProperty('dateTime') ? overrides.dateTime! : 'Word',
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 1,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'A sentence',
+        enum: overrides && overrides.hasOwnProperty('enum') ? overrides.enum! : EnumExample.Lorem,
+    };
+};
+
+export const aD = (overrides?: Partial<D>): D => {
+    return {
+        nested: overrides && overrides.hasOwnProperty('nested') ? overrides.nested! : aC(),
+    };
+};
+"
+`;

--- a/tests/perTypeFieldGeneration/spec.ts
+++ b/tests/perTypeFieldGeneration/spec.ts
@@ -954,7 +954,7 @@ describe('per-type random generator using casual', () => {
             expect(result).toBeDefined();
 
             // String
-            expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas'");
+            expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea'");
 
             expect(result).toMatchSnapshot();
         });

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`choosing random generator using faker should generate random scalars using faker 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'dae147b0-0c04-459e-92db-724dd87433b4',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas accusamus eos',
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'dicta',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : 695,
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : 0.51,
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : true,
+    };
+};
+"
+`;
+
 exports[`should generate custom scalars for native and custom types using casual 1`] = `
 "
 export const anA = (overrides?: Partial<A>): A => {

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`choosing random dynamic generator using casual should generate random scalars using casual 1`] = `
+"import casual from 'casual';
+
+casual.seed(0);
+
+const weightedChoice = (weights, random) => {
+    const totalWeight = weights.reduce((acc, weight) => acc + weight, 0);
+    let randomNum = random() * totalWeight;
+    for (let i = 0; i < weights.length; i++) {
+        if (randomNum <= weights[i]) {
+            return i;
+        }
+        randomNum -= weights[i];
+    }
+    throw new Error('Something went wrong in weightedChoice.');
+}
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : [() => casual['integer'](...[101,1000]), () => casual['integer'](...[1,100])][weightedChoice([1,99], () => casual.double(0, 1.0))](),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual.word,
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : casual.word,
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : casual.integer(0, 9999),
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : Math.round(casual.double(0, 10) * 100) / 100,
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : casual.boolean,
+    };
+};
+
+export const seedMocks = (seed: number) => casual.seed(seed);
+"
+`;
+
 exports[`choosing random dynamic generator using faker should generate random scalars using faker 1`] = `
 "import { faker } from '@faker-js/faker';
 
@@ -9,7 +47,7 @@ const weightedChoice = (weights, random) => {
     const totalWeight = weights.reduce((acc, weight) => acc + weight, 0);
     let randomNum = random() * totalWeight;
     for (let i = 0; i < weights.length; i++) {
-        if (randomNum < weights[i]) {
+        if (randomNum <= weights[i]) {
             return i;
         }
         randomNum -= weights[i];
@@ -35,6 +73,27 @@ export const aB = (overrides?: Partial<B>): B => {
 };
 
 export const seedMocks = (seed: number) => faker.seed(seed);
+"
+`;
+
+exports[`choosing random generator using casual should generate random scalars using casual 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'cae147b0-1c04-459e-82db-624dd87433b4',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas',
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'dicta',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : 696,
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : 7.55,
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
 "
 `;
 

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -81,7 +81,7 @@ exports[`choosing random generator using casual should generate random scalars u
 export const anA = (overrides?: Partial<A>): A => {
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'cae147b0-1c04-459e-82db-624dd87433b4',
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea',
         obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
         anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'dicta',
     };

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -90,7 +90,7 @@ export const anA = (overrides?: Partial<A>): A => {
 export const aB = (overrides?: Partial<B>): B => {
     return {
         int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : 696,
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : 7.55,
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : 0.51,
         bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
     };
 };

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`choosing random dynamic generator using faker should generate random scalars using faker 1`] = `
+"import { faker } from '@faker-js/faker';
+
+faker.seed(0);
+
+const weightedChoice = (weights, random) => {
+    const totalWeight = weights.reduce((acc, weight) => acc + weight, 0);
+    let randomNum = random() * totalWeight;
+    for (let i = 0; i < weights.length; i++) {
+        if (randomNum < weights[i]) {
+            return i;
+        }
+        randomNum -= weights[i];
+    }
+    throw new Error('Something went wrong in weightedChoice.');
+}
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker.datatype.uuid(),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : [() => faker['lorem']['sentence'](...[3]), () => faker['lorem']['words'](...[3])][weightedChoice([1,99], () => faker.datatype.float({ max: 1.0 }))](),
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : faker.lorem.word(),
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : faker.datatype.number({ min: 0, max: 9999 }),
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : faker.datatype.float({ min: 0, max: 10, precision: 0.1 }),
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : faker.datatype.boolean(),
+    };
+};
+
+export const seedMocks = (seed: number) => faker.seed(seed);
+"
+`;
+
 exports[`choosing random generator using faker should generate random scalars using faker 1`] = `
 "
 export const anA = (overrides?: Partial<A>): A => {

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -47,6 +47,34 @@ it('should generate custom scalars for native and custom types using casual', as
     expect(result).toMatchSnapshot();
 });
 
+describe('choosing random generator using casual', () => {
+    const config = {
+        generateLibrary: 'casual',
+        scalars: {
+            String: ['string', 'word'],
+        },
+    } as TypescriptMocksPluginConfig;
+
+    beforeEach(() => {
+        jest.spyOn(faker.datatype, 'float').mockReturnValue(0.51);
+    });
+
+    afterEach(() => {
+        jest.spyOn(faker.datatype, 'float').mockRestore();
+    });
+
+    it('should generate random scalars using casual', async () => {
+        const result = await plugin(testSchema, [], config);
+
+        expect(result).toBeDefined();
+
+        // String
+        expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas',");
+
+        expect(result).toMatchSnapshot();
+    });
+});
+
 it('should generate dynamic custom scalars for native and custom types using casual', async () => {
     const result = await plugin(testSchema, [], {
         dynamicValues: true,
@@ -93,6 +121,48 @@ it('should generate dynamic custom scalars for native and custom types using cas
     );
 
     expect(result).toMatchSnapshot();
+});
+
+describe('choosing random dynamic generator using casual', () => {
+    const config = {
+        generateLibrary: 'casual',
+        defineWeightedChoice: true,
+        dynamicValues: true,
+        scalars: {
+            ID: [
+                {
+                    generator: 'integer',
+                    arguments: [101, 1000],
+                },
+                {
+                    generator: 'integer',
+                    arguments: [1, 100],
+                    weight: 99,
+                },
+            ],
+        },
+    } as TypescriptMocksPluginConfig;
+
+    beforeEach(() => {
+        jest.spyOn(faker.datatype, 'float').mockReturnValue(0.02);
+    });
+
+    afterEach(() => {
+        jest.spyOn(faker.datatype, 'float').mockRestore();
+    });
+
+    it('should generate random scalars using casual', async () => {
+        const result = await plugin(testSchema, [], config);
+
+        expect(result).toBeDefined();
+
+        // String
+        expect(result).toContain(
+            "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : [() => casual['integer'](...[101,1000]), () => casual['integer'](...[1,100])][weightedChoice([1,99], () => casual.double(0, 1.0))]()",
+        );
+
+        expect(result).toMatchSnapshot();
+    });
 });
 
 it('should generate custom scalars for native and custom types using faker', async () => {

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -219,3 +219,45 @@ it('should generate dynamic custom scalars for native and custom types using fak
 
     expect(result).toMatchSnapshot();
 });
+
+describe('choosing random dynamic generator using faker', () => {
+    const config = {
+        generateLibrary: 'faker',
+        defineWeightedChoice: true,
+        dynamicValues: true,
+        scalars: {
+            String: [
+                {
+                    generator: 'lorem.sentence',
+                    arguments: [3],
+                },
+                {
+                    generator: 'lorem.words',
+                    arguments: [3],
+                    weight: 99,
+                },
+            ],
+        },
+    } as TypescriptMocksPluginConfig;
+
+    beforeEach(() => {
+        jest.spyOn(faker.datatype, 'float').mockReturnValue(0.02);
+    });
+
+    afterEach(() => {
+        jest.spyOn(faker.datatype, 'float').mockRestore();
+    });
+
+    it('should generate random scalars using faker', async () => {
+        const result = await plugin(testSchema, [], config);
+
+        expect(result).toBeDefined();
+
+        // String
+        expect(result).toContain(
+            "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : [() => faker['lorem']['sentence'](...[3]), () => faker['lorem']['words'](...[3])][weightedChoice([1,99], () => faker.datatype.float({ max: 1.0 }))]()",
+        );
+
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import casual from 'casual';
 import { TypescriptMocksPluginConfig, plugin } from '../../src';
 import testSchema from './schema';
 
@@ -56,14 +57,14 @@ describe('choosing random generator using casual', () => {
     } as TypescriptMocksPluginConfig;
 
     beforeEach(() => {
-        jest.spyOn(faker.datatype, 'float').mockReturnValue(0.51);
+        jest.spyOn(casual, 'double').mockReturnValue(0.51);
     });
 
     afterEach(() => {
-        jest.spyOn(faker.datatype, 'float').mockRestore();
+        jest.spyOn(casual, 'double').mockRestore();
     });
 
-    it('should generate random scalars using casual', async () => {
+    fit('should generate random scalars using casual', async () => {
         const result = await plugin(testSchema, [], config);
 
         expect(result).toBeDefined();
@@ -144,11 +145,11 @@ describe('choosing random dynamic generator using casual', () => {
     } as TypescriptMocksPluginConfig;
 
     beforeEach(() => {
-        jest.spyOn(faker.datatype, 'float').mockReturnValue(0.02);
+        jest.spyOn(casual, 'double').mockReturnValue(0.02);
     });
 
     afterEach(() => {
-        jest.spyOn(faker.datatype, 'float').mockRestore();
+        jest.spyOn(casual, 'double').mockRestore();
     });
 
     it('should generate random scalars using casual', async () => {

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -1,4 +1,5 @@
-import { plugin } from '../../src';
+import { faker } from '@faker-js/faker';
+import { TypescriptMocksPluginConfig, plugin } from '../../src';
 import testSchema from './schema';
 
 it('should generate custom scalars for native and custom types using casual', async () => {
@@ -136,6 +137,36 @@ it('should generate custom scalars for native and custom types using faker', asy
     expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
 
     expect(result).toMatchSnapshot();
+});
+
+describe('choosing random generator using faker', () => {
+    const config = {
+        generateLibrary: 'faker',
+        scalars: {
+            String: ['lorem.sentence', 'lorem.words'],
+        },
+    } as TypescriptMocksPluginConfig;
+
+    beforeEach(() => {
+        jest.spyOn(faker.datatype, 'float').mockReturnValue(0.51);
+    });
+
+    afterEach(() => {
+        jest.spyOn(faker.datatype, 'float').mockRestore();
+    });
+
+    it('should generate random scalars using faker', async () => {
+        const result = await plugin(testSchema, [], config);
+
+        expect(result).toBeDefined();
+
+        // String
+        expect(result).toContain(
+            "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas accusamus eos',",
+        );
+
+        expect(result).toMatchSnapshot();
+    });
 });
 
 it('should generate dynamic custom scalars for native and custom types using faker', async () => {

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -70,7 +70,7 @@ describe('choosing random generator using casual', () => {
         expect(result).toBeDefined();
 
         // String
-        expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'quas',");
+        expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea'");
 
         expect(result).toMatchSnapshot();
     });


### PR DESCRIPTION
First off, this is a great package that I've found to be a real help in creating Storybook stories and test data. I hope this contribution seems useful!

I found it useful to have generators that provide more variety than is available from calling a single casual or faker generator (for instance, fields which are often null but occasionally have data). While this is possible via custom code, I prefer to make it more explicit through the configuration itself.

This PR adds support for passing an array of generator options to both the `scalar` and `fieldGeneration` options. If an array is provided, one option will be chosen at random each time a value is generated. By default each is equally likely, but a `weight` parameter can be specified to change the relative likelihood of each option.

Examples from the docs:

```yaml
fieldName: # will be null 3/4 of the time, contain the output of faker.lorem.paragraphs() the other 1/4
  - generator: 'null'
    weight: 3
  - lorem.paragraphs
```

which could also be written as:

```yaml
fieldName: # will be null 3/4 of the time, contain the output of faker.lorem.paragraphs() the other 1/4
  - 'null'
  - 'null'
  - 'null'
  - lorem.paragraphs
```
