### PR TITLE
fix: type error when using typesPrefix and terminateCircularRelationships

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -366,16 +366,26 @@ const getNamedType = (opts: Options<NamedTypeNode | ObjectTypeDefinitionNode>): 
                 }
             }
             if (opts.terminateCircularRelationships) {
-                return handleValueGeneration(
-                    opts,
-                    null,
-                    () =>
-                        `relationshipsToOmit.has('${casedName}') ? {} as ${casedName} : ${toMockName(
+                return handleValueGeneration(opts, null, () => {
+                    if (opts.typesPrefix) {
+                        const typeNameConverter = createNameConverter(
+                            opts.typeNamesConvention,
+                            opts.transformUnderscore,
+                        );
+                        const casedNameWithPrefix = typeNameConverter(name, opts.typesPrefix);
+                        return `relationshipsToOmit.has('${casedName}') ? {} as ${casedNameWithPrefix} : ${toMockName(
                             name,
                             casedName,
                             opts.prefix,
-                        )}({}, relationshipsToOmit)`,
-                );
+                        )}({}, relationshipsToOmit)`;
+                    } else {
+                        return `relationshipsToOmit.has('${casedName}') ? {} as ${casedName} : ${toMockName(
+                            name,
+                            casedName,
+                            opts.prefix,
+                        )}({}, relationshipsToOmit)`;
+                    }
+                });
             } else {
                 return handleValueGeneration(opts, null, () => `${toMockName(name, casedName, opts.prefix)}()`);
             }

--- a/tests/typesPrefixAndTerminateCircularRelationships/__snapshots__/spec.ts.snap
+++ b/tests/typesPrefixAndTerminateCircularRelationships/__snapshots__/spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should support typesPrefix and terminateCircularRelationships at the same time 1`] = `
+"
+export const mockA = (overrides?: Partial<MockA>, _relationshipsToOmit: Set<string> = new Set()): MockA => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('A');
+    return {
+        b: overrides && overrides.hasOwnProperty('b') ? overrides.b! : relationshipsToOmit.has('B') ? {} as MockB : mockB({}, relationshipsToOmit),
+    };
+};
+
+export const mockB = (overrides?: Partial<MockB>, _relationshipsToOmit: Set<string> = new Set()): MockB => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('B');
+    return {
+        a: overrides && overrides.hasOwnProperty('a') ? overrides.a! : relationshipsToOmit.has('A') ? {} as MockA : mockA({}, relationshipsToOmit),
+    };
+};
+"
+`;

--- a/tests/typesPrefixAndTerminateCircularRelationships/schema.ts
+++ b/tests/typesPrefixAndTerminateCircularRelationships/schema.ts
@@ -1,0 +1,10 @@
+import { buildSchema } from 'graphql';
+
+export default buildSchema(/* GraphQL */ `
+    type A {
+        b: B!
+    }
+    type B {
+        a: A!
+    }
+`);

--- a/tests/typesPrefixAndTerminateCircularRelationships/spec.ts
+++ b/tests/typesPrefixAndTerminateCircularRelationships/spec.ts
@@ -1,0 +1,16 @@
+import { plugin } from '../../src';
+import testSchema from './schema';
+
+it('should support typesPrefix and terminateCircularRelationships at the same time', async () => {
+    const result = await plugin(testSchema, [], {
+        prefix: 'mock',
+        typesPrefix: 'Mock',
+        terminateCircularRelationships: true,
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toContain(
+        "a: overrides && overrides.hasOwnProperty('a') ? overrides.a! : relationshipsToOmit.has('A') ? {} as MockA : mockA({}, relationshipsToOmit)",
+    );
+    expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
Fixing when using `typesPrefix` and `terminateCircularRelationships` simultaneously, a type error occurred because typesPrefix was not applied in the type cast of an empty object.
