### PR TITLE
feat(terminateCircularRelationships): Add 'immediate' as a value for the terminateCircularRelationships option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ Adds `__typename` property to mock data
 
 Changes enums to TypeScript string union types
 
-### terminateCircularRelationships (`boolean`, defaultValue: `false`)
+### terminateCircularRelationships (`boolean | 'immediate'`, defaultValue: `false`)
 
 When enabled, prevents circular relationships from triggering infinite recursion. After the first resolution of a
 specific type in a particular call stack, subsequent resolutions will return an empty object cast to the correct type.
+
+When enabled with `immediate`, it will only resolve the relationship once, independently of the call stack. Use this option if you're experiencing `out of memory` errors while generating mocks.
 
 ### prefix (`string`, defaultValue: `a` for consonants & `an` for vowels)
 

--- a/tests/terminateCircularRelationshipsImmediately/__snapshots__/spec.ts.snap
+++ b/tests/terminateCircularRelationshipsImmediately/__snapshots__/spec.ts.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should support setting terminateCircularRelationships as imediate and not create a new set of relationships 1`] = `
+"
+export const anA = (overrides?: Partial<A>, _relationshipsToOmit: Set<string> = new Set()): A => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('A');
+    return {
+        B: overrides && overrides.hasOwnProperty('B') ? overrides.B! : relationshipsToOmit.has('B') ? {} as B : aB({}, relationshipsToOmit),
+        C: overrides && overrides.hasOwnProperty('C') ? overrides.C! : relationshipsToOmit.has('C') ? {} as C : aC({}, relationshipsToOmit),
+    };
+};
+
+export const aB = (overrides?: Partial<B>, _relationshipsToOmit: Set<string> = new Set()): B => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('B');
+    return {
+        A: overrides && overrides.hasOwnProperty('A') ? overrides.A! : relationshipsToOmit.has('A') ? {} as A : anA({}, relationshipsToOmit),
+    };
+};
+
+export const aC = (overrides?: Partial<C>, _relationshipsToOmit: Set<string> = new Set()): C => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('C');
+    return {
+        aCollection: overrides && overrides.hasOwnProperty('aCollection') ? overrides.aCollection! : [relationshipsToOmit.has('A') ? {} as A : anA({}, relationshipsToOmit)],
+    };
+};
+
+export const aD = (overrides?: Partial<D>, _relationshipsToOmit: Set<string> = new Set()): D => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('D');
+    return {
+        A: overrides && overrides.hasOwnProperty('A') ? overrides.A! : relationshipsToOmit.has('A') ? {} as A : anA({}, relationshipsToOmit),
+        B: overrides && overrides.hasOwnProperty('B') ? overrides.B! : relationshipsToOmit.has('B') ? {} as B : aB({}, relationshipsToOmit),
+    };
+};
+"
+`;

--- a/tests/terminateCircularRelationshipsImmediately/schema.ts
+++ b/tests/terminateCircularRelationshipsImmediately/schema.ts
@@ -1,0 +1,18 @@
+import { buildSchema } from 'graphql';
+
+export default buildSchema(/* GraphQL */ `
+    type A {
+        B: B!
+        C: C!
+    }
+    type B {
+        A: A!
+    }
+    type C {
+        aCollection: [A!]!
+    }
+    type D {
+        A: A!
+        B: B!
+    }
+`);

--- a/tests/terminateCircularRelationshipsImmediately/spec.ts
+++ b/tests/terminateCircularRelationshipsImmediately/spec.ts
@@ -1,0 +1,12 @@
+import { plugin } from '../../src';
+import testSchema from './schema';
+
+it('should support setting terminateCircularRelationships as imediate and not create a new set of relationships', async () => {
+    const result = await plugin(testSchema, [], {
+        terminateCircularRelationships: 'immediate',
+    });
+
+    expect(result).toBeDefined();
+    expect(result).not.toContain('new Set(_relationshipsToOmit)');
+    expect(result).toMatchSnapshot();
+});

--- a/tests/terminateCircularRelationshipsImmediately/types.ts
+++ b/tests/terminateCircularRelationshipsImmediately/types.ts
@@ -1,0 +1,17 @@
+export type A = {
+    B: B;
+    C: C;
+};
+
+export type B = {
+    A: A;
+};
+
+export type C = {
+    aCollection: A[];
+};
+
+export type D = {
+    A: A;
+    B: B;
+};


### PR DESCRIPTION
This value will make the mock not create a new Set of relationships to ignore and create a global Set. This will circumvent possible OOM due to large graphs.

fixes #126 