### PR TITLE
feat: add includedTypes and excludedTypes options for selective mock generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,34 @@ Adds `__typename` property to mock data
 
 Changes enums to TypeScript string union types
 
+### includedTypes (`string[]`, defaultValue: `undefined`)
+
+Specifies an array of types to **include** in the mock generation. When provided, only the types listed in this array will have mock data generated.
+
+Example:
+
+```yaml
+plugins:
+  - typescript-mock-data:
+      includedTypes:
+        - User
+        - Avatar
+```
+
+### excludedTypes (`string[]`, defaultValue: `undefined`)
+
+Specifies an array of types to **exclude** in the mock generation. When provided, the types listed in this array will not have mock data generated.
+
+Example:
+
+```yaml
+plugins:
+  - typescript-mock-data:
+      excludedTypes:
+        - User
+        - Avatar
+```
+
 ### terminateCircularRelationships (`boolean | 'immediate'`, defaultValue: `false`)
 
 When enabled, prevents circular relationships from triggering infinite recursion. After the first resolution of a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "graphql-codegen-typescript-mock-data",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "description": "GraphQL Codegen plugin for building mock data",
     "main": "dist/commonjs/index.js",
     "module": "dist/esnext/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -837,6 +837,9 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
 
     const { includedTypes, excludedTypes } = config;
     const shouldGenerateMockForType = (typeName: string) => {
+        if (!typeName) {
+            return true;
+        }
         if (includedTypes && includedTypes.length > 0) {
             return includedTypes.includes(typeName);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -839,7 +839,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
     const result = oldVisit(astNode, { leave: visitor });
 
     const { includedTypes, excludedTypes } = config;
-    const shouldGenerateMockForType = (typeName: string) => {
+    const shouldGenerateMockForType = (typeName?: string) => {
         if (!typeName) {
             return true;
         }

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1594,6 +1594,32 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 "
 `;
 
+exports[`should generate mock data only for included types 1`] = `
+"
+export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
+    };
+};
+
+export const aUser = (overrides?: Partial<User>): User => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'arx',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+    };
+};
+"
+`;
+
 exports[`should generate mock data with PascalCase enum values by default 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1030,63 +1030,6 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 "
 `;
 
-exports[`should exclude specified types from mock generation 1`] = `
-"
-export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-    };
-};
-
-export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
-    };
-};
-
-export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>): PrefixedResponse => {
-    return {
-        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'nam',
-    };
-};
-
-export const anAbcType = (overrides?: Partial<AbcType>): AbcType => {
-    return {
-        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'accommodo',
-    };
-};
-
-export const aListType = (overrides?: Partial<ListType>): ListType => {
-    return {
-        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['accusator'],
-        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['tricesimus'],
-    };
-};
-
-export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
-        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
-        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
-    };
-};
-
-export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
-    return {
-        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
-    };
-};
-
-export const aQuery = (overrides?: Partial<Query>): Query => {
-    return {
-        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : aUser(),
-        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : aPrefixedResponse(),
-    };
-};
-"
-`;
-
 exports[`should generate dynamic values in mocks 1`] = `
 "import { fakerEN as faker } from '@faker-js/faker';
 

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -603,6 +603,7 @@ it('should generate mock data only for included types', async () => {
         includedTypes: ['User', 'Avatar'],
     });
 
+    expect(result).toMatchSnapshot();
     expect(result).toBeDefined();
     expect(result).toContain('export const aUser');
     expect(result).toContain('export const anAvatar');

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -597,3 +597,38 @@ it('overriding works as expected when defaultNullableToNull is true', async () =
 
     expect(result).toMatchSnapshot();
 });
+
+it('should generate mock data only for included types', async () => {
+    const result = await plugin(testSchema, [], {
+        includedTypes: ['User', 'Avatar'],
+    });
+
+    expect(result).toBeDefined();
+    expect(result).toContain('export const aUser');
+    expect(result).toContain('export const anAvatar');
+    expect(result).not.toContain('export const aPrefixedResponse');
+    expect(result).not.toContain('export const aCamelCaseThing');
+});
+
+it('should exclude specified types from mock generation', async () => {
+    const result = await plugin(testSchema, [], {
+        excludedTypes: ['User', 'Avatar'],
+    });
+
+    expect(result).toBeDefined();
+    expect(result).not.toContain('export const aUser');
+    expect(result).not.toContain('export const anAvatar');
+    expect(result).toContain('export const aPrefixedResponse');
+    expect(result).toContain('export const aCamelCaseThing');
+});
+
+it('should prioritize includedTypes over excludedTypes if both are specified', async () => {
+    const result = await plugin(testSchema, [], {
+        includedTypes: ['User'],
+        excludedTypes: ['User', 'Avatar'],
+    });
+    expect(result).toBeDefined();
+    expect(result).toContain('export const aUser');
+    expect(result).not.toContain('export const anAvatar');
+    expect(result).not.toContain('export const aPrefixedResponse');
+});


### PR DESCRIPTION
This PR introduces two new configuration options, `includedTypes` and `excludedTypes`, to the `graphql-codegen-typescript-mock-data` plugin for enhanced control over mock data generation:

### **Changes Introduced:**
1. **`includedTypes` (Array of strings):**  
   - Allows specifying an array of types to **include** in the mock generation.  
   - Only the types listed in `includedTypes` will have mock data generated.
   
2. **`excludedTypes` (Array of strings):**  
   - Allows specifying an array of types to **exclude** from the mock generation.  
   - Types listed in `excludedTypes` will **not** have mock data generated.
   
3. **Precedence:**  
   - If both `includedTypes` and `excludedTypes` are provided, `includedTypes` takes **precedence** over `excludedTypes`.

### **Examples:**

**1. `includedTypes` Example:**
```yaml
plugins:
  - typescript-mock-data:
      includedTypes:
        - User
        - Avatar
```
In this configuration, mock data will be generated only for `User` and `Avatar` types.

**2. `excludedTypes` Example:**
```yaml
plugins:
  - typescript-mock-data:
      excludedTypes:
        - User
        - Avatar
```
In this configuration, `User` and `Avatar` types will be excluded from mock data generation.

**3. Combined `includedTypes` and `excludedTypes`:**
```yaml
plugins:
  - typescript-mock-data:
      includedTypes:
        - User
      excludedTypes:
        - User
        - Avatar
```
In this example, despite being listed in `excludedTypes`, `User` will still have mock data generated because `includedTypes` takes precedence.

### **Documentation Updates:**
- Added descriptions for `includedTypes` and `excludedTypes` in the README.md.
- Added examples demonstrating how to use these options.

### **Tests:**
- Added unit tests to validate the behavior of `includedTypes` and `excludedTypes`:
  - Mock generation for included types.
  - Exclusion of specific types.
  - Precedence handling when both options are provided.

---

This update provides flexibility for users to selectively include or exclude types, making mock data generation more efficient and tailored to specific testing needs.

