### PR TITLE
Fix: handling useImplementingTypes and defaultNullableToNull

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -371,14 +371,17 @@ const getNamedType = (opts: Options<NamedTypeNode | ObjectTypeDefinitionNode>): 
                         )
                             break;
 
-                        return foundTypes
-                            .map((implementType: TypeItem) =>
-                                getNamedImplementType({
-                                    ...opts,
-                                    currentType: implementType.types,
-                                }),
-                            )
-                            .join(' || ');
+                        return (
+                            foundTypes
+                                .map((implementType: TypeItem) =>
+                                    getNamedImplementType({
+                                        ...opts,
+                                        currentType: implementType.types,
+                                    }),
+                                )
+                                .filter((value) => value !== null)
+                                .join(' || ') || null
+                        );
                     default:
                         throw `foundType is unknown: ${foundType.name}: ${foundType.type}`;
                 }

--- a/tests/useImplementingTypesAndDefaultNullableToNull/__snapshots__/spec.ts.snap
+++ b/tests/useImplementingTypesAndDefaultNullableToNull/__snapshots__/spec.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should support useImplementingTypes 1`] = `
+"
+export const mockRoot = (overrides?: Partial<Root>): Root => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : null,
+    };
+};
+
+export const mockA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : null,
+    };
+};
+
+export const mockB = (overrides?: Partial<B>): B => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : null,
+    };
+};
+
+export const mockC = (overrides?: Partial<C>): C => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : null,
+    };
+};
+
+export const mockD = (overrides?: Partial<D>): D => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : null,
+    };
+};
+
+export const mockTest = (overrides?: Partial<Test>): Test => {
+    return {
+        field1: overrides && overrides.hasOwnProperty('field1') ? overrides.field1! : mockA() || mockB() || mockC() || mockD(),
+        field2: overrides && overrides.hasOwnProperty('field2') ? overrides.field2! : null,
+    };
+};
+"
+`;

--- a/tests/useImplementingTypesAndDefaultNullableToNull/schema.ts
+++ b/tests/useImplementingTypesAndDefaultNullableToNull/schema.ts
@@ -1,0 +1,28 @@
+import { buildSchema } from 'graphql';
+
+export default buildSchema(/* GraphQL */ `
+    interface Root {
+        id: ID
+    }
+
+    type A implements Root {
+        id: ID
+    }
+
+    type B implements Root {
+        id: ID
+    }
+
+    type C implements Root {
+        id: ID
+    }
+
+    type D implements Root {
+        id: ID
+    }
+
+    type Test {
+        field1: Root!
+        field2: Root
+    }
+`);

--- a/tests/useImplementingTypesAndDefaultNullableToNull/spec.ts
+++ b/tests/useImplementingTypesAndDefaultNullableToNull/spec.ts
@@ -1,0 +1,20 @@
+import { plugin } from '../../src';
+import testSchema from './schema';
+
+it('should support useImplementingTypes', async () => {
+    const result = await plugin(testSchema, [], {
+        prefix: 'mock',
+        useImplementingTypes: true,
+        defaultNullableToNull: true,
+    });
+
+    expect(result).toBeDefined();
+
+    expect(result).toContain(
+        "field1: overrides && overrides.hasOwnProperty('field1') ? overrides.field1! : mockA() || mockB() || mockC() || mockD(),",
+    );
+
+    expect(result).toContain("field2: overrides && overrides.hasOwnProperty('field2') ? overrides.field2! : null,");
+
+    expect(result).toMatchSnapshot();
+});


### PR DESCRIPTION
Hi @ardeois , thank you for the great package!

When `useImplementingTypes` and `defaultNullableToNull` are used at the same time, the plugin outputs weird `|| || || ||` in generated fixtures. This PR fixes this problem.