### PR TITLE
feature(scalars): support distinction between input and output generator configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ keep all GraphQL names as-is. Available case functions in `change-case-all` are 
 `localeLowerCase`, `lowerCaseFirst`, `spongeCase`, `titleCase`, `upperCase`, `localeUpperCase` and `upperCaseFirst`
 [See more](https://github.com/btxtiger/change-case-all)
 
-### scalars (`{ [Scalar: string]: GeneratorOptions }`, defaultValue: `undefined`)
+### scalars (`{ [Scalar: string]: GeneratorOptions | InputOutputGeneratorOptions }`, defaultValue: `undefined`)
 
 Allows you to define mappings for your custom scalars. Allows you to map any GraphQL Scalar to a
 [casual](https://github.com/boo1ean/casual#embedded-generators) embedded generator (string or
@@ -369,6 +369,24 @@ fieldName: # gets translated to casual.integer.toFixed(3)
   extra:
     function: toFixed
     arguments: 3
+```
+
+### `InputOutputGeneratorOptions` type
+
+This type is used in the `scalars` option. It allows you to specify different `GeneratorOptions` for `input` and `output` types for
+your scalars, in the same way the [typescript-operations](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#scalars) plugin does.
+
+So, using the first example of the previous section, you can specify a `string` for your input and a `Date` for your `output`:
+
+```yaml
+plugins:
+  - typescript-mock-data:
+      scalars:
+        Date:
+          input: date.weekday # Date fields in input objects will be mocked as strings
+          output:
+            generator: date.past # Date fields in other GraphQL types will be mocked as JS Dates
+            arguments: 10
 ```
 
 ## Examples of usage

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,11 +102,11 @@ const getGeneratorDefinition = (
         };
     }
 
-    if ('input' in value && 'output' in value) {
+    if (value !== undefined && 'input' in value && 'output' in value) {
         return getGeneratorDefinition(value[generatorMode], generatorMode);
     }
 
-    return value;
+    return value as GeneratorDefinition;
 };
 
 const getCasualCustomValue = (

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -176,3 +176,62 @@ export const aC = (overrides?: Partial<C>): C => {
 export const seedMocks = (seed: number) => faker.seed(seed);
 "
 `;
+
+exports[`custom scalar generation using faker with different input/output configurations should generate distinct custom scalars for native and custom input/output types 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Orlando_Cremin@gmail.com',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'vilicus',
+    };
+};
+"
+`;
+
+exports[`custom scalar generation using faker with different input/output configurations should generate distinct dynamic custom scalars for native and custom types 1`] = `
+"import { fakerEN as faker } from '@faker-js/faker';
+
+faker.seed(0);
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['number']['int'](...[{\\"min\\":1,\\"max\\":100}]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : faker['internet']['email'](),
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : faker['number']['int'](...[{\\"min\\":-100,\\"max\\":0}]),
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : faker['number']['float'](...[{\\"min\\":-100,\\"max\\":0}]),
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : faker['lorem']['word'](),
+    };
+};
+
+export const seedMocks = (seed: number) => faker.seed(seed);
+"
+`;

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -18,6 +18,12 @@ export const aB = (overrides?: Partial<B>): B => {
         bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
     };
 };
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Gianni_Kutch@hotmail.com',
+    };
+};
 "
 `;
 
@@ -37,6 +43,12 @@ export const aB = (overrides?: Partial<B>): B => {
         int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
         flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,
         bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Maia49@hotmail.com',
     };
 };
 "
@@ -64,6 +76,12 @@ export const aB = (overrides?: Partial<B>): B => {
     };
 };
 
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : casual['email'],
+    };
+};
+
 export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
@@ -87,6 +105,12 @@ export const aB = (overrides?: Partial<B>): B => {
         int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : faker['number']['int'](...[{\\"min\\":-100,\\"max\\":0}]),
         flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : faker['number']['float'](...[{\\"min\\":-100,\\"max\\":0}]),
         bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : faker['internet']['email'](),
     };
 };
 

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`custom scalar generation for native and custom types using casual should generate custom scalars for native and custom types using casual 1`] = `
+exports[`Custom scalar generation using casual should generate custom scalars for native and custom types 1`] = `
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
@@ -27,7 +27,7 @@ export const aC = (overrides?: Partial<C>): C => {
 "
 `;
 
-exports[`custom scalar generation for native and custom types using casual should generate dynamic custom scalars for native and custom types using casual 1`] = `
+exports[`Custom scalar generation using casual should generate dynamic custom scalars for native and custom types 1`] = `
 "import casual from 'casual';
 
 casual.seed(0);
@@ -59,7 +59,66 @@ export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
 
-exports[`custom scalar generation for native and custom types using faker should generate custom scalars for native and custom types using faker 1`] = `
+exports[`Custom scalar generation using casual with different input/output configurations should generate distinct custom scalars for native and custom input/output types 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Kelly_Cremin@Turcotte.biz',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'itaque distinctio iure molestias voluptas reprehenderit quos',
+    };
+};
+"
+`;
+
+exports[`Custom scalar generation using casual with different input/output configurations should generate distinct dynamic custom scalars for native and custom types 1`] = `
+"import casual from 'casual';
+
+casual.seed(0);
+
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual['integer'](...[1,100]),
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['string'],
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : casual['email'],
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : casual['integer'](...[-100,0]),
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : casual['double'](...[-100,0]),
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : casual['string'],
+    };
+};
+
+export const seedMocks = (seed: number) => casual.seed(seed);
+"
+`;
+
+exports[`custom scalar generation using faker should generate custom scalars for native and custom types 1`] = `
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
@@ -86,7 +145,7 @@ export const aC = (overrides?: Partial<C>): C => {
 "
 `;
 
-exports[`custom scalar generation for native and custom types using faker should generate dynamic custom scalars for native and custom types using faker 1`] = `
+exports[`custom scalar generation using faker should generate dynamic custom scalars for native and custom types 1`] = `
 "import { fakerEN as faker } from '@faker-js/faker';
 
 faker.seed(0);

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should generate custom scalars for native and custom types using casual 1`] = `
+exports[`custom scalar generation for native and custom types using casual should generate custom scalars for native and custom types using casual 1`] = `
 "
 export const anA = (overrides?: Partial<A>): A => {
     return {
@@ -27,34 +27,7 @@ export const aC = (overrides?: Partial<C>): C => {
 "
 `;
 
-exports[`should generate custom scalars for native and custom types using faker 1`] = `
-"
-export const anA = (overrides?: Partial<A>): A => {
-    return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',
-        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Orlando_Cremin@gmail.com',
-    };
-};
-
-export const aB = (overrides?: Partial<B>): B => {
-    return {
-        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
-        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,
-        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
-    };
-};
-
-export const aC = (overrides?: Partial<C>): C => {
-    return {
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Maia49@hotmail.com',
-    };
-};
-"
-`;
-
-exports[`should generate dynamic custom scalars for native and custom types using casual 1`] = `
+exports[`custom scalar generation for native and custom types using casual should generate dynamic custom scalars for native and custom types using casual 1`] = `
 "import casual from 'casual';
 
 casual.seed(0);
@@ -86,7 +59,34 @@ export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
 
-exports[`should generate dynamic custom scalars for native and custom types using faker 1`] = `
+exports[`custom scalar generation for native and custom types using faker should generate custom scalars for native and custom types using faker 1`] = `
+"
+export const anA = (overrides?: Partial<A>): A => {
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',
+        obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Orlando_Cremin@gmail.com',
+    };
+};
+
+export const aB = (overrides?: Partial<B>): B => {
+    return {
+        int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,
+        flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,
+        bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false,
+    };
+};
+
+export const aC = (overrides?: Partial<C>): C => {
+    return {
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Maia49@hotmail.com',
+    };
+};
+"
+`;
+
+exports[`custom scalar generation for native and custom types using faker should generate dynamic custom scalars for native and custom types using faker 1`] = `
 "import { fakerEN as faker } from '@faker-js/faker';
 
 faker.seed(0);

--- a/tests/scalars/schema.ts
+++ b/tests/scalars/schema.ts
@@ -15,4 +15,8 @@ export default buildSchema(/* GraphQL */ `
         flt: Float!
         bool: Boolean!
     }
+
+    input C {
+        anyObject: AnyObject!
+    }
 `);

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -320,4 +320,127 @@ describe('custom scalar generation using faker', () => {
 
         expect(result).toMatchSnapshot();
     });
+
+    describe('with different input/output configurations', () => {
+        it('should generate distinct custom scalars for native and custom input/output types', async () => {
+            const result = await plugin(testSchema, [], {
+                generateLibrary: 'faker',
+                scalars: {
+                    String: 'lorem.sentence',
+                    Float: {
+                        generator: 'number.float',
+                        arguments: [{ min: -100, max: 0, fractionDigits: 2 }],
+                    },
+                    ID: {
+                        generator: 'number.int',
+                        arguments: [{ min: 1, max: 100 }],
+                    },
+                    Boolean: 'false',
+                    Int: {
+                        generator: 'number.int',
+                        arguments: [{ min: -100, max: 0 }],
+                    },
+                    AnyObject: {
+                        input: 'lorem.word',
+                        output: 'internet.email',
+                    },
+                },
+            });
+
+            expect(result).toBeDefined();
+
+            // String
+            expect(result).toContain(
+                "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',",
+            );
+
+            // Float
+            expect(result).toContain("flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,");
+
+            // ID
+            expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,");
+
+            // Boolean
+            expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+
+            // Int
+            expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
+
+            // AnyObject in type A (an email)
+            expect(result).toContain(
+                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Orlando_Cremin@gmail.com',",
+            );
+
+            // AnyObject in input C (a string)
+            expect(result).toContain(
+                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'vilicus',",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
+        it('should generate distinct dynamic custom scalars for native and custom types', async () => {
+            const result = await plugin(testSchema, [], {
+                generateLibrary: 'faker',
+                dynamicValues: true,
+                scalars: {
+                    String: 'lorem.sentence',
+                    Float: {
+                        generator: 'number.float',
+                        arguments: [{ min: -100, max: 0 }],
+                    },
+                    ID: {
+                        generator: 'number.int',
+                        arguments: [{ min: 1, max: 100 }],
+                    },
+                    Boolean: 'false',
+                    Int: {
+                        generator: 'number.int',
+                        arguments: [{ min: -100, max: 0 }],
+                    },
+                    AnyObject: {
+                        input: 'lorem.word',
+                        output: 'internet.email',
+                    },
+                },
+            });
+
+            expect(result).toBeDefined();
+
+            // String
+            expect(result).toContain(
+                "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),",
+            );
+
+            // Float
+            expect(result).toContain(
+                "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : faker['number']['float'](...[{\"min\":-100,\"max\":0}]),",
+            );
+
+            // ID
+            expect(result).toContain(
+                "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['number']['int'](...[{\"min\":1,\"max\":100}]),",
+            );
+
+            // Boolean
+            expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+
+            // Int
+            expect(result).toContain(
+                "int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : faker['number']['int'](...[{\"min\":-100,\"max\":0}]),",
+            );
+
+            // AnyObject in type A (an email)
+            expect(result).toContain(
+                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : faker['internet']['email'](),",
+            );
+
+            // AnyObject in input C (a string)
+            expect(result).toContain(
+                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : faker['lorem']['word'](),",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+    });
 });

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -98,6 +98,131 @@ describe('Custom scalar generation using casual', () => {
 
         expect(result).toMatchSnapshot();
     });
+
+    describe('with different input/output configurations', () => {
+        it('should generate distinct custom scalars for native and custom input/output types', async () => {
+            const result = await plugin(testSchema, [], {
+                generateLibrary: 'casual',
+                scalars: {
+                    String: 'string',
+                    Float: {
+                        generator: 'double',
+                        arguments: [-100, 0],
+                    },
+                    ID: {
+                        generator: 'integer',
+                        arguments: [1, 100],
+                    },
+                    Boolean: 'false',
+                    Int: {
+                        generator: 'integer',
+                        arguments: [-100, 0],
+                    },
+                    AnyObject: {
+                        input: 'string',
+                        output: 'email',
+                    },
+                },
+            });
+
+            expect(result).toBeDefined();
+
+            // String
+            expect(result).toContain(
+                "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',",
+            );
+
+            // Float
+            expect(result).toContain(
+                "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,",
+            );
+
+            // ID
+            expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,");
+
+            // Boolean
+            expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+
+            // Int
+            expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
+
+            // AnyObject in type A (an email)
+            expect(result).toContain(
+                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Kelly_Cremin@Turcotte.biz',",
+            );
+
+            // AnyObject in input C (a string)
+            expect(result).toContain(
+                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'itaque distinctio iure molestias voluptas reprehenderit quos',",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+
+        it('should generate distinct dynamic custom scalars for native and custom types', async () => {
+            const result = await plugin(testSchema, [], {
+                generateLibrary: 'casual',
+                dynamicValues: true,
+                scalars: {
+                    String: 'string',
+                    Float: {
+                        generator: 'double',
+                        arguments: [-100, 0],
+                    },
+                    ID: {
+                        generator: 'integer',
+                        arguments: [1, 100],
+                    },
+                    Boolean: 'false',
+                    Int: {
+                        generator: 'integer',
+                        arguments: [-100, 0],
+                    },
+                    AnyObject: {
+                        input: 'string',
+                        output: 'email',
+                    },
+                },
+            });
+
+            expect(result).toBeDefined();
+
+            // String
+            expect(result).toContain(
+                "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['string'],",
+            );
+
+            // Float
+            expect(result).toContain(
+                "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : casual['double'](...[-100,0]),",
+            );
+
+            // ID
+            expect(result).toContain(
+                "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual['integer'](...[1,100]),",
+            );
+
+            // Boolean
+            expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+
+            // Int
+            expect(result).toContain(
+                "int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : casual['integer'](...[-100,0]),",
+            );
+
+            // AnyObject in type A (an email)
+            expect(result).toContain(
+                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : casual['email'],",
+            );
+
+            // AnyObject in input C (an string)
+            expect(result).toContain(
+                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : casual['string'],",
+            );
+
+            expect(result).toMatchSnapshot();
+        });
+    });
 });
 
 describe('custom scalar generation using faker', () => {

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -1,192 +1,198 @@
 import { plugin } from '../../src';
 import testSchema from './schema';
 
-it('should generate custom scalars for native and custom types using casual', async () => {
-    const result = await plugin(testSchema, [], {
-        generateLibrary: 'casual',
-        scalars: {
-            String: 'string',
-            Float: {
-                generator: 'double',
-                arguments: [-100, 0],
+describe('Custom scalar generation using casual', () => {
+    it('should generate custom scalars for native and custom types', async () => {
+        const result = await plugin(testSchema, [], {
+            generateLibrary: 'casual',
+            scalars: {
+                String: 'string',
+                Float: {
+                    generator: 'double',
+                    arguments: [-100, 0],
+                },
+                ID: {
+                    generator: 'integer',
+                    arguments: [1, 100],
+                },
+                Boolean: 'false',
+                Int: {
+                    generator: 'integer',
+                    arguments: [-100, 0],
+                },
+                AnyObject: 'email',
             },
-            ID: {
-                generator: 'integer',
-                arguments: [1, 100],
-            },
-            Boolean: 'false',
-            Int: {
-                generator: 'integer',
-                arguments: [-100, 0],
-            },
-            AnyObject: 'email',
-        },
+        });
+
+        expect(result).toBeDefined();
+
+        // String
+        expect(result).toContain(
+            "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',",
+        );
+
+        // Float
+        expect(result).toContain(
+            "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,",
+        );
+
+        // ID
+        expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,");
+
+        // Boolean
+        expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+
+        // Int
+        expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
+
+        expect(result).toMatchSnapshot();
     });
 
-    expect(result).toBeDefined();
+    it('should generate dynamic custom scalars for native and custom types', async () => {
+        const result = await plugin(testSchema, [], {
+            generateLibrary: 'casual',
+            dynamicValues: true,
+            scalars: {
+                String: 'string',
+                Float: {
+                    generator: 'double',
+                    arguments: [-100, 0],
+                },
+                ID: {
+                    generator: 'integer',
+                    arguments: [1, 100],
+                },
+                Boolean: 'false',
+                Int: {
+                    generator: 'integer',
+                    arguments: [-100, 0],
+                },
+                AnyObject: 'email',
+            },
+        });
 
-    // String
-    expect(result).toContain(
-        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',",
-    );
+        expect(result).toBeDefined();
 
-    // Float
-    expect(result).toContain(
-        "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,",
-    );
+        // String
+        expect(result).toContain(
+            "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['string'],",
+        );
 
-    // ID
-    expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,");
+        // Float
+        expect(result).toContain(
+            "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : casual['double'](...[-100,0]),",
+        );
 
-    // Boolean
-    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+        // ID
+        expect(result).toContain(
+            "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual['integer'](...[1,100]),",
+        );
 
-    // Int
-    expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
+        // Boolean
+        expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
 
-    expect(result).toMatchSnapshot();
+        // Int
+        expect(result).toContain(
+            "int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : casual['integer'](...[-100,0]),",
+        );
+
+        expect(result).toMatchSnapshot();
+    });
 });
 
-it('should generate dynamic custom scalars for native and custom types using casual', async () => {
-    const result = await plugin(testSchema, [], {
-        generateLibrary: 'casual',
-        dynamicValues: true,
-        scalars: {
-            String: 'string',
-            Float: {
-                generator: 'double',
-                arguments: [-100, 0],
+describe('custom scalar generation using faker', () => {
+    it('should generate custom scalars for native and custom types', async () => {
+        const result = await plugin(testSchema, [], {
+            generateLibrary: 'faker',
+            scalars: {
+                String: 'lorem.sentence',
+                Float: {
+                    generator: 'number.float',
+                    arguments: [{ min: -100, max: 0, fractionDigits: 2 }],
+                },
+                ID: {
+                    generator: 'number.int',
+                    arguments: [{ min: 1, max: 100 }],
+                },
+                Boolean: 'false',
+                Int: {
+                    generator: 'number.int',
+                    arguments: [{ min: -100, max: 0 }],
+                },
+                AnyObject: 'internet.email',
             },
-            ID: {
-                generator: 'integer',
-                arguments: [1, 100],
-            },
-            Boolean: 'false',
-            Int: {
-                generator: 'integer',
-                arguments: [-100, 0],
-            },
-            AnyObject: 'email',
-        },
+        });
+
+        expect(result).toBeDefined();
+
+        // String
+        expect(result).toContain(
+            "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',",
+        );
+
+        // Float
+        expect(result).toContain("flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,");
+
+        // ID
+        expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,");
+
+        // Boolean
+        expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+
+        // Int
+        expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
+
+        expect(result).toMatchSnapshot();
     });
 
-    expect(result).toBeDefined();
-
-    // String
-    expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : casual['string'],");
-
-    // Float
-    expect(result).toContain(
-        "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : casual['double'](...[-100,0]),",
-    );
-
-    // ID
-    expect(result).toContain(
-        "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : casual['integer'](...[1,100]),",
-    );
-
-    // Boolean
-    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
-
-    // Int
-    expect(result).toContain(
-        "int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : casual['integer'](...[-100,0]),",
-    );
-
-    expect(result).toMatchSnapshot();
-});
-
-it('should generate custom scalars for native and custom types using faker', async () => {
-    const result = await plugin(testSchema, [], {
-        generateLibrary: 'faker',
-        scalars: {
-            String: 'lorem.sentence',
-            Float: {
-                generator: 'number.float',
-                arguments: [{ min: -100, max: 0, fractionDigits: 2 }],
+    it('should generate dynamic custom scalars for native and custom types', async () => {
+        const result = await plugin(testSchema, [], {
+            generateLibrary: 'faker',
+            dynamicValues: true,
+            scalars: {
+                String: 'lorem.sentence',
+                Float: {
+                    generator: 'number.float',
+                    arguments: [{ min: -100, max: 0 }],
+                },
+                ID: {
+                    generator: 'number.int',
+                    arguments: [{ min: 1, max: 100 }],
+                },
+                Boolean: 'false',
+                Int: {
+                    generator: 'number.int',
+                    arguments: [{ min: -100, max: 0 }],
+                },
+                AnyObject: 'internet.email',
             },
-            ID: {
-                generator: 'number.int',
-                arguments: [{ min: 1, max: 100 }],
-            },
-            Boolean: 'false',
-            Int: {
-                generator: 'number.int',
-                arguments: [{ min: -100, max: 0 }],
-            },
-            AnyObject: 'internet.email',
-        },
+        });
+
+        expect(result).toBeDefined();
+
+        // String
+        expect(result).toContain(
+            "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),",
+        );
+
+        // Float
+        expect(result).toContain(
+            "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : faker['number']['float'](...[{\"min\":-100,\"max\":0}]),",
+        );
+
+        // ID
+        expect(result).toContain(
+            "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['number']['int'](...[{\"min\":1,\"max\":100}]),",
+        );
+
+        // Boolean
+        expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
+
+        // Int
+        expect(result).toContain(
+            "int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : faker['number']['int'](...[{\"min\":-100,\"max\":0}]),",
+        );
+
+        expect(result).toMatchSnapshot();
     });
-
-    expect(result).toBeDefined();
-
-    // String
-    expect(result).toContain(
-        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',",
-    );
-
-    // Float
-    expect(result).toContain("flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,");
-
-    // ID
-    expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,");
-
-    // Boolean
-    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
-
-    // Int
-    expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
-
-    expect(result).toMatchSnapshot();
-});
-
-it('should generate dynamic custom scalars for native and custom types using faker', async () => {
-    const result = await plugin(testSchema, [], {
-        generateLibrary: 'faker',
-        dynamicValues: true,
-        scalars: {
-            String: 'lorem.sentence',
-            Float: {
-                generator: 'number.float',
-                arguments: [{ min: -100, max: 0 }],
-            },
-            ID: {
-                generator: 'number.int',
-                arguments: [{ min: 1, max: 100 }],
-            },
-            Boolean: 'false',
-            Int: {
-                generator: 'number.int',
-                arguments: [{ min: -100, max: 0 }],
-            },
-            AnyObject: 'internet.email',
-        },
-    });
-
-    expect(result).toBeDefined();
-
-    // String
-    expect(result).toContain(
-        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : faker['lorem']['sentence'](),",
-    );
-
-    // Float
-    expect(result).toContain(
-        "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : faker['number']['float'](...[{\"min\":-100,\"max\":0}]),",
-    );
-
-    // ID
-    expect(result).toContain(
-        "id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : faker['number']['int'](...[{\"min\":1,\"max\":100}]),",
-    );
-
-    // Boolean
-    expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
-
-    // Int
-    expect(result).toContain(
-        "int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : faker['number']['int'](...[{\"min\":-100,\"max\":0}]),",
-    );
-
-    expect(result).toMatchSnapshot();
 });


### PR DESCRIPTION
This addresses https://github.com/ardeois/graphql-codegen-typescript-mock-data/issues/139. 

To do so:
- I added a new type, `InputOutputGeneratorOptions`, and added it as a `ScalarMap` option
- I updated `Options` to have a `generatorMode` field, which is either `input` or `output`
- We pass options with one or the other to `generateMockValue` depending on whether we're visiting a `FieldDefinition` or a `InputObjectTypeDefinition` node. We do this and the above because ...
- ...we have to update `getGeneratorDefinition` with the mode to be able to know how to pluck out the appropriate generator when `value` is an `InputOutputGeneratorOptions`.