### PR TITLE
feat: upgrade to @faker-js/faker v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Feel free to open issues and pull requests. We always welcome support from the c
 
 To run this project locally:
 
-- Use Node >= 16
+- Use Node >= 18
 - Make sure that you have the latest Yarn version (https://yarnpkg.com/lang/en/docs/install/)
 - Clone this repo using `git clone`
 - Run `yarn`

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "fakes"
     ],
     "dependencies": {
-        "@faker-js/faker": "^8.4.1",
+        "@faker-js/faker": "^9.8.0",
         "@graphql-codegen/plugin-helpers": "^5.0.4",
         "@graphql-tools/utils": "^10.7.2",
         "casual": "^1.6.2",
@@ -34,7 +34,11 @@
         "upper-case": "^2.0.1"
     },
     "peerDependencies": {
-        "graphql": "^14.6.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^14.6.0 || ^15.0.0 || ^16.0.0",
+        "typescript": ">=5.0.0"
+    },
+    "engines": {
+        "node": ">=18.0.0"
     },
     "devDependencies": {
         "@auto-it/conventional-commits": "^11.1.6",

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -4,15 +4,15 @@ exports[`defaults all nullable fields to null when defaultNullableToNull is set 
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -26,14 +26,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -58,7 +58,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : null,
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
     };
@@ -89,15 +89,15 @@ exports[`overriding works as expected when defaultNullableToNull is true 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : someAvatar,
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -111,14 +111,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -143,7 +143,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : null,
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : null,
     };
@@ -174,15 +174,15 @@ exports[`should add custom prefix if the \`prefix\` config option is specified 1
 "
 export const mockAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const mockUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -196,14 +196,14 @@ export const mockUser = (overrides?: Partial<User>): User => {
 
 export const mockWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
     };
 };
 
 export const mockCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -228,7 +228,7 @@ export const mockListType = (overrides?: Partial<ListType>): ListType => {
 
 export const mockUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : mockAvatar(),
     };
@@ -259,15 +259,15 @@ exports[`should add enumsPrefix to all enums when option is specified 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
@@ -281,14 +281,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -313,7 +313,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -345,15 +345,15 @@ exports[`should add enumsPrefix to imports 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
@@ -367,14 +367,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -399,7 +399,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -431,15 +431,15 @@ exports[`should add typesPrefix and enumsPrefix to imports 1`] = `
 
 export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<Api.User>): Api.User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Api.Status.Online,
@@ -453,14 +453,14 @@ export const aUser = (overrides?: Partial<Api.User>): Api.User => {
 
 export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -485,7 +485,7 @@ export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -516,15 +516,15 @@ exports[`should add typesPrefix to all types when option is specified 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<Api.User>): Api.User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -538,14 +538,14 @@ export const aUser = (overrides?: Partial<Api.User>): Api.User => {
 
 export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -570,7 +570,7 @@ export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -602,15 +602,15 @@ exports[`should add typesPrefix to imports 1`] = `
 
 export const anAvatar = (overrides?: Partial<Api.Avatar>): Api.Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<Api.User>): Api.User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -624,14 +624,14 @@ export const aUser = (overrides?: Partial<Api.User>): Api.User => {
 
 export const aWithAvatar = (overrides?: Partial<Api.WithAvatar>): Api.WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<Api.CamelCaseThing>): Api.CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -656,7 +656,7 @@ export const aListType = (overrides?: Partial<Api.ListType>): Api.ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api.UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -687,20 +687,20 @@ exports[`should correctly generate the \`faker\` data for a function with argume
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : \\"2024-10-29T22:31:35.873Z\\",
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : \\"2024-10-29T22:31:35.882Z\\",
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
         prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
@@ -709,14 +709,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -741,7 +741,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -772,20 +772,20 @@ exports[`should correctly generate the \`faker\` data for a function with one ar
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : \\"2024-10-29T22:31:35.873Z\\",
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : \\"2024-10-29T22:31:35.882Z\\",
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
         prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
@@ -794,14 +794,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -826,7 +826,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -857,20 +857,20 @@ exports[`should correctly generate the \`faker\` data for a non-string scalar ma
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,98,185],
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : [41,185,232],
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
         prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
@@ -879,14 +879,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -911,7 +911,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -942,20 +942,20 @@ exports[`should correctly generate the \`faker\` data for a scalar mapping of ty
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
         customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
-        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Geovany63@gmail.com',
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'Mohammad_Nikolaus@gmail.com',
         camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : aCamelCaseThing(),
         unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : anAvatar(),
         prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
@@ -964,14 +964,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -996,7 +996,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -1027,15 +1027,15 @@ exports[`should correctly use custom generator as default value 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1049,14 +1049,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -1081,7 +1081,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -1292,15 +1292,15 @@ exports[`should generate mock data functions 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1314,14 +1314,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -1346,7 +1346,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -1463,15 +1463,15 @@ exports[`should generate mock data functions with external types file import 1`]
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1485,14 +1485,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -1517,7 +1517,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -1548,15 +1548,15 @@ exports[`should generate mock data functions with faker 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1570,14 +1570,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -1602,7 +1602,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -1633,15 +1633,15 @@ exports[`should generate mock data functions with scalars 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1655,14 +1655,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -1687,7 +1687,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -1718,15 +1718,15 @@ exports[`should generate mock data only for included types 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1744,15 +1744,15 @@ exports[`should generate mock data with PascalCase enum values by default 1`] = 
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1766,14 +1766,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -1798,7 +1798,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -1829,15 +1829,15 @@ exports[`should generate mock data with PascalCase enum values if enumValues is 
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1851,14 +1851,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -1883,7 +1883,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -1914,15 +1914,15 @@ exports[`should generate mock data with PascalCase enum values if typeNames is "
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -1936,14 +1936,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -1968,7 +1968,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2000,15 +2000,15 @@ exports[`should generate mock data with PascalCase types and enums by default 1`
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -2022,14 +2022,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2054,7 +2054,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2085,15 +2085,15 @@ exports[`should generate mock data with as-is enum values as string union type i
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
@@ -2107,14 +2107,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2139,7 +2139,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2170,15 +2170,15 @@ exports[`should generate mock data with as-is enum values if enumValues is "keep
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
@@ -2192,14 +2192,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2224,7 +2224,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2255,15 +2255,15 @@ exports[`should generate mock data with as-is types and enums if typeNames is "k
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -2277,14 +2277,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const acamelCaseThing = (overrides?: Partial<camelCaseThing>): camelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2309,7 +2309,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2340,15 +2340,15 @@ exports[`should generate mock data with enum values as string union type if enum
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
@@ -2362,14 +2362,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2394,7 +2394,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2425,15 +2425,15 @@ exports[`should generate mock data with enum values as string union type if enum
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : ('ONLINE' as Status),
@@ -2447,14 +2447,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2479,7 +2479,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2511,7 +2511,7 @@ exports[`should generate mock data with typename if addTypename is true 1`] = `
 export const anAvatar = (overrides?: Partial<Avatar>): { __typename: 'Avatar' } & Avatar => {
     return {
         __typename: 'Avatar',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
@@ -2519,8 +2519,8 @@ export const anAvatar = (overrides?: Partial<Avatar>): { __typename: 'Avatar' } 
 export const aUser = (overrides?: Partial<User>): { __typename: 'User' } & User => {
     return {
         __typename: 'User',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -2535,7 +2535,7 @@ export const aUser = (overrides?: Partial<User>): { __typename: 'User' } & User 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): { __typename: 'WithAvatar' } & WithAvatar => {
     return {
         __typename: 'WithAvatar',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
@@ -2543,7 +2543,7 @@ export const aWithAvatar = (overrides?: Partial<WithAvatar>): { __typename: 'Wit
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): { __typename: 'camelCaseThing' } & CamelCaseThing => {
     return {
         __typename: 'camelCaseThing',
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2571,7 +2571,7 @@ export const aListType = (overrides?: Partial<ListType>): { __typename: 'ListTyp
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2604,15 +2604,15 @@ exports[`should generate mock data with upperCase enum values if enumValues is "
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.ONLINE,
@@ -2626,14 +2626,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2658,7 +2658,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2689,15 +2689,15 @@ exports[`should generate mock data with upperCase types and enums if typeNames i
 "
 export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUSER = (overrides?: Partial<USER>): USER => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
@@ -2711,14 +2711,14 @@ export const aUSER = (overrides?: Partial<USER>): USER => {
 
 export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>): WITHAVATAR => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
     };
 };
 
 export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>): CAMELCASETHING => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2743,7 +2743,7 @@ export const aLISTTYPE = (overrides?: Partial<LISTTYPE>): LISTTYPE => {
 
 export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>): UPDATEUSERINPUT => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
     };
@@ -2775,15 +2775,15 @@ exports[`should generate mock data with upperCase types and imports if typeNames
 
 export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUSER = (overrides?: Partial<USER>): USER => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : STATUS.Online,
@@ -2797,14 +2797,14 @@ export const aUSER = (overrides?: Partial<USER>): USER => {
 
 export const aWITHAVATAR = (overrides?: Partial<WITHAVATAR>): WITHAVATAR => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
     };
 };
 
 export const aCAMELCASETHING = (overrides?: Partial<CAMELCASETHING>): CAMELCASETHING => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2829,7 +2829,7 @@ export const aLISTTYPE = (overrides?: Partial<LISTTYPE>): LISTTYPE => {
 
 export const anUPDATEUSERINPUT = (overrides?: Partial<UPDATEUSERINPUT>): UPDATEUSERINPUT => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAVATAR(),
     };
@@ -2861,15 +2861,15 @@ exports[`should generate multiple list elements 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -2883,14 +2883,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -2915,7 +2915,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -2947,15 +2947,15 @@ exports[`should generate no list elements when listElementCount is 0 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -2969,14 +2969,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -3001,7 +3001,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -3033,15 +3033,15 @@ exports[`should generate single list element 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -3055,14 +3055,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -3087,7 +3087,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -3119,15 +3119,15 @@ exports[`should not merge imports into one if enumsPrefix does not contain dots 
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : ApiStatus.Online,
@@ -3141,14 +3141,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -3173,7 +3173,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -3205,15 +3205,15 @@ exports[`should not merge imports into one if typesPrefix does not contain dots 
 
 export const anAvatar = (overrides?: Partial<ApiAvatar>): ApiAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<ApiUser>): ApiUser => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -3227,14 +3227,14 @@ export const aUser = (overrides?: Partial<ApiUser>): ApiUser => {
 
 export const aWithAvatar = (overrides?: Partial<ApiWithAvatar>): ApiWithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<ApiCamelCaseThing>): ApiCamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -3259,7 +3259,7 @@ export const aListType = (overrides?: Partial<ApiListType>): ApiListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<ApiUpdateUserInput>): ApiUpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -3291,15 +3291,15 @@ exports[`should preserve underscores if transformUnderscore is false 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -3313,14 +3313,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -3345,7 +3345,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -3377,15 +3377,15 @@ exports[`should preserve underscores if transformUnderscore is false and enumsAs
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : 'ONLINE',
@@ -3399,14 +3399,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -3431,7 +3431,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -3463,15 +3463,15 @@ exports[`should preserve underscores if transformUnderscore is false and enumsAs
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : ('ONLINE' as Status),
@@ -3485,14 +3485,14 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -3517,7 +3517,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
@@ -3550,7 +3550,7 @@ export const anAvatar = (overrides?: Partial<Avatar>, _relationshipsToOmit: Set<
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('Avatar');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
@@ -3559,8 +3559,8 @@ export const aUser = (overrides?: Partial<User>, _relationshipsToOmit: Set<strin
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('User');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -3576,7 +3576,7 @@ export const aWithAvatar = (overrides?: Partial<WithAvatar>, _relationshipsToOmi
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('WithAvatar');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
     };
 };
@@ -3585,7 +3585,7 @@ export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _relationsh
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('CamelCaseThing');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -3618,7 +3618,7 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _relatio
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('UpdateUserInput');
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
     };

--- a/tests/generateLibrary/faker/__snapshots__/spec.ts.snap
+++ b/tests/generateLibrary/faker/__snapshots__/spec.ts.snap
@@ -2,24 +2,24 @@
 
 exports[`should generate dynamic values when dynamicValues is true 1`] = `
 Object {
-  "id": "89bd9d8d-69a6-474e-80f4-67cc8796ed15",
+  "id": "8b986a7e-f6c8-49e1-910d-cdfc7c1a2f86",
   "obj": Object {
-    "bool": false,
-    "flt": 3.7,
-    "int": 202,
+    "bool": true,
+    "flt": 5.7,
+    "int": 4561,
   },
-  "str": "socius",
+  "str": "teres",
 }
 `;
 
 exports[`should generate dynamic values when dynamicValues is true 2`] = `
 Object {
-  "id": "fc2ddf7c-c78c-4a1b-8a92-8fc816742cb7",
+  "id": "999fa56b-0aa3-4255-997f-132a47321a23",
   "obj": Object {
     "bool": true,
-    "flt": 0.1,
-    "int": 1352,
+    "flt": 8.4,
+    "int": 971,
   },
-  "str": "minus",
+  "str": "trado",
 }
 `;

--- a/tests/scalars/__snapshots__/spec.ts.snap
+++ b/tests/scalars/__snapshots__/spec.ts.snap
@@ -123,9 +123,9 @@ exports[`custom scalar generation using faker should generate custom scalars for
 export const anA = (overrides?: Partial<A>): A => {
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Nulla blanditiis defetiscor usque adduco eveniet.',
         obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Orlando_Cremin@gmail.com',
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Kelly60@gmail.com',
     };
 };
 
@@ -139,7 +139,7 @@ export const aB = (overrides?: Partial<B>): B => {
 
 export const aC = (overrides?: Partial<C>): C => {
     return {
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Maia49@hotmail.com',
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Gianni_Kulas29@yahoo.com',
     };
 };
 "
@@ -182,9 +182,9 @@ exports[`custom scalar generation using faker with different input/output config
 export const anA = (overrides?: Partial<A>): A => {
     return {
         id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,
-        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',
+        str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Nulla blanditiis defetiscor usque adduco eveniet.',
         obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : aB(),
-        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Orlando_Cremin@gmail.com',
+        anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Kelly60@gmail.com',
     };
 };
 

--- a/tests/scalars/spec.ts
+++ b/tests/scalars/spec.ts
@@ -27,17 +27,15 @@ describe('Custom scalar generation using casual', () => {
         expect(result).toBeDefined();
 
         // String
-        expect(result).toContain(
-            "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'ea corrupti qui incidunt eius consequatur blanditiis',",
-        );
+        expect(result).toMatch(/str: overrides && overrides\.hasOwnProperty\('str'\) \? overrides\.str! : '[^']+',/);
 
         // Float
-        expect(result).toContain(
-            "flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.509902694262564,",
+        expect(result).toMatch(
+            /flt: overrides && overrides\.hasOwnProperty\('flt'\) \? overrides\.flt! : -?\d+\.?\d*,/,
         );
 
         // ID
-        expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 82,");
+        expect(result).toMatch(/id: overrides && overrides\.hasOwnProperty\('id'\) \? overrides\.id! : \d+,/);
 
         // Boolean
         expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
@@ -251,15 +249,15 @@ describe('custom scalar generation using faker', () => {
         expect(result).toBeDefined();
 
         // String
-        expect(result).toContain(
-            "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',",
-        );
+        expect(result).toMatch(/str: overrides && overrides\.hasOwnProperty\('str'\) \? overrides\.str! : '[^']+',/);
 
         // Float
-        expect(result).toContain("flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,");
+        expect(result).toMatch(
+            /flt: overrides && overrides\.hasOwnProperty\('flt'\) \? overrides\.flt! : -?\d+\.?\d*,/,
+        );
 
         // ID
-        expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,");
+        expect(result).toMatch(/id: overrides && overrides\.hasOwnProperty\('id'\) \? overrides\.id! : \d+,/);
 
         // Boolean
         expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
@@ -350,15 +348,17 @@ describe('custom scalar generation using faker', () => {
             expect(result).toBeDefined();
 
             // String
-            expect(result).toContain(
-                "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Depereo nulla calco blanditiis cornu defetiscor.',",
+            expect(result).toMatch(
+                /str: overrides && overrides\.hasOwnProperty\('str'\) \? overrides\.str! : '[^']+',/,
             );
 
             // Float
-            expect(result).toContain("flt: overrides && overrides.hasOwnProperty('flt') ? overrides.flt! : -24.51,");
+            expect(result).toMatch(
+                /flt: overrides && overrides\.hasOwnProperty\('flt'\) \? overrides\.flt! : -?\d+\.?\d*,/,
+            );
 
             // ID
-            expect(result).toContain("id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 83,");
+            expect(result).toMatch(/id: overrides && overrides\.hasOwnProperty\('id'\) \? overrides\.id! : \d+,/);
 
             // Boolean
             expect(result).toContain("bool: overrides && overrides.hasOwnProperty('bool') ? overrides.bool! : false");
@@ -366,14 +366,14 @@ describe('custom scalar generation using faker', () => {
             // Int
             expect(result).toContain("int: overrides && overrides.hasOwnProperty('int') ? overrides.int! : -93,");
 
-            // AnyObject in type A (an email)
-            expect(result).toContain(
-                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'Orlando_Cremin@gmail.com',",
+            // AnyObject in type A (an email) - use regex pattern instead of hardcoded email
+            expect(result).toMatch(
+                /anyObject: overrides && overrides\.hasOwnProperty\('anyObject'\) \? overrides\.anyObject! : '[^@]+@[^.]+\.[^']+',/,
             );
 
-            // AnyObject in input C (a string)
-            expect(result).toContain(
-                "anyObject: overrides && overrides.hasOwnProperty('anyObject') ? overrides.anyObject! : 'vilicus',",
+            // AnyObject in input C (a string) - use regex pattern instead of hardcoded word
+            expect(result).toMatch(
+                /anyObject: overrides && overrides\.hasOwnProperty\('anyObject'\) \? overrides\.anyObject! : '[^']+',/,
             );
 
             expect(result).toMatchSnapshot();

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -299,7 +299,7 @@ it('should correctly generate the `faker` data for a scalar mapping of type stri
     const result = await plugin(testSchema, [], { scalars: { AnyObject: 'internet.email' } });
 
     expect(result).toBeDefined();
-    expect(result).toContain('Geovany63@gmail.com');
+    expect(result).toMatch(/@[a-zA-Z0-9]+\.(com|org|net)/);
     expect(result).toMatchSnapshot();
 });
 
@@ -309,7 +309,7 @@ it('should correctly generate the `faker` data for a non-string scalar mapping',
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain(JSON.stringify([41, 98, 185]));
+    expect(result).toMatch(/\[\d+,\d+,\d+\]/);
     expect(result).toMatchSnapshot();
 });
 
@@ -324,7 +324,7 @@ it('should correctly generate the `faker` data for a function with arguments sca
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain('"2024-10-29T22:31:35.873Z"');
+    expect(result).toMatch(/"20\d{2}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"/);
     expect(result).toMatchSnapshot();
 });
 
@@ -339,7 +339,7 @@ it('should correctly generate the `faker` data for a function with one argument 
     });
 
     expect(result).toBeDefined();
-    expect(result).toContain('"2024-10-29T22:31:35.873Z"');
+    expect(result).toMatch(/"20\d{2}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"/);
     expect(result).toMatchSnapshot();
 });
 

--- a/tests/useImplementingTypes/__snapshots__/spec.ts.snap
+++ b/tests/useImplementingTypes/__snapshots__/spec.ts.snap
@@ -22,7 +22,7 @@ export const mockAction = (overrides?: Partial<Action>): Action => {
 
 export const mockA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'dae147b0-0c04-459e-912d-b724dd87433b',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'de4b005e-2b2d-4843-94d1-d356d75d933b',
         str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'cuius',
         obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : mockB(),
         config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : mockTestAConfig() || mockTestTwoAConfig(),
@@ -85,7 +85,7 @@ export const mockAction = (overrides?: Partial<Action>): Action => {
 
 export const mockA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'dae147b0-0c04-459e-912d-b724dd87433b',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'de4b005e-2b2d-4843-94d1-d356d75d933b',
         str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'cuius',
         obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : mockB(),
         config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : mockAConfig(),
@@ -148,10 +148,10 @@ export const mockAction = (overrides?: Partial<Action>): Action => {
 
 export const mockA = (overrides?: Partial<A>): A => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'dae147b0-0c04-459e-912d-b724dd87433b',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'de4b005e-2b2d-4843-94d1-d356d75d933b',
         str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'cuius',
         obj: overrides && overrides.hasOwnProperty('obj') ? overrides.obj! : mockB(),
-        config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : 'Kian.Keeling70@gmail.com',
+        config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : 'Karen.Prosacco@gmail.com',
         configArray: overrides && overrides.hasOwnProperty('configArray') ? overrides.configArray! : [mockTestAConfig() || mockTestTwoAConfig()],
         field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : mockTestTwoAConfig(),
         action: overrides && overrides.hasOwnProperty('action') ? overrides.action! : mockTestAction(),

--- a/tests/useImplementingTypes/spec.ts
+++ b/tests/useImplementingTypes/spec.ts
@@ -46,8 +46,8 @@ it(`support useImplementingTypes with fieldGeneration prop`, async () => {
     });
     expect(result).toBeDefined();
 
-    expect(result).toContain(
-        "str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'Jeanie.Fay45@yahoo.com'",
+    expect(result).toMatch(
+        /str: overrides && overrides\.hasOwnProperty\('str'\) \? overrides\.str! : '[^@]+@[^.]+\.[^']+'/,
     );
 
     expect(result).toContain(
@@ -65,8 +65,8 @@ it(`support useImplementingTypes with fieldGeneration prop`, async () => {
 
     expect(result).toContain("str: overrides && overrides.hasOwnProperty('str') ? overrides.str! : 'cuius'");
 
-    expect(result).toContain(
-        "config: overrides && overrides.hasOwnProperty('config') ? overrides.config! : 'Kian.Keeling70@gmail.com',",
+    expect(result).toMatch(
+        /config: overrides && overrides\.hasOwnProperty\('config'\) \? overrides\.config! : '[^@]+@[^.]+\.[^']+',/,
     );
 
     expect(result).toMatchSnapshot();

--- a/tests/useTypeImports/__snapshots__/spec.ts.snap
+++ b/tests/useTypeImports/__snapshots__/spec.ts.snap
@@ -5,15 +5,15 @@ exports[`should support useTypeImports 1`] = `
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '1550ff93-cd31-49b4-a3c3-8ef1cb68bdc3',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
         url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
     };
 };
 
 export const aUser = (overrides?: Partial<User>): User => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b5756f00-51a6-422a-81a7-dc13ee6a6375',
-        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-06-27T14:29:24.774Z',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
         status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
@@ -27,20 +27,20 @@ export const aUser = (overrides?: Partial<User>): User => {
 
 export const aPartial = (overrides?: Partial<Partial>): Partial => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '262c8866-bf76-4ccf-b606-2a0b4742f81f',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '2286b7cf-0204-44f1-bc80-c295b5723a4b',
     };
 };
 
 export const aWithAvatar = (overrides?: Partial<WithAvatar>): WithAvatar => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '99f515e7-21e0-461d-b823-0d4c7f4dafc5',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };
 };
 
 export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>): CamelCaseThing => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '245b9cf9-10fa-4974-8100-fbeee5ee7fd4',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
     };
 };
 
@@ -65,7 +65,7 @@ export const aListType = (overrides?: Partial<ListType>): ListType => {
 
 export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateUserInput => {
     return {
-        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0d6a9360-d92b-4660-b1e5-f14155047bdd',
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
         login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
         avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : anAvatar(),
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,10 +941,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@faker-js/faker@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
-  integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
+"@faker-js/faker@^9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-9.8.0.tgz#3344284028d1c9dc98dee2479f82939310370d88"
+  integrity sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==
 
 "@graphql-codegen/plugin-helpers@^5.0.3", "@graphql-codegen/plugin-helpers@^5.0.4":
   version "5.0.4"


### PR DESCRIPTION
The upgrade was pretty much seamless, except the test suite, which hard-codes values in a way that ties them to the seed used.

I opted for a regex approach that would make the broken tests work before and after, and for future seeds. That may not be desirable, though. Let me know if you want me to just update the values to effectively be snapshots.

Closes #186

---

This release upgrades to Faker v9, which introduces several breaking changes:

- **Node.js v18+ required**: Faker v9 requires Node.js v18 or higher
- **TypeScript v5+ required**: Faker v9 requires TypeScript v5 or higher
- **Different mock values**: Due to Faker v9's improved RNG (53-bit vs 32-bit), generated mock values will be different even with the same seed
- **Removed deprecated code**: Faker v8 had deprecated many methods, [which have now been removed](https://fakerjs.dev/guide/upgrading.html#removals-of-deprecated-code)

For more details, see the [Faker v9 migration guide](https://fakerjs.dev/guide/upgrading.html).