### PR TITLE
Fix type errors in generated code for nested input objects with @oneOf directive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { parse, TypeNode, ASTKindToNode, ListTypeNode, NamedTypeNode, ObjectTypeDefinitionNode } from 'graphql';
+import { parse, TypeNode, ASTKindToNode, ListTypeNode, NamedTypeNode, ObjectTypeDefinitionNode, Kind } from 'graphql';
 import * as allFakerLocales from '@faker-js/faker';
 import casual from 'casual';
 import { oldVisit, PluginFunction, resolveExternalModuleAndFn } from '@graphql-codegen/plugin-helpers';
@@ -409,6 +409,7 @@ const getNamedType = (opts: Options<NamedTypeNode | ObjectTypeDefinitionNode>): 
                         throw `foundType is unknown: ${foundType.name}: ${foundType.type}`;
                 }
             }
+
             if (opts.terminateCircularRelationships) {
                 return handleValueGeneration(opts, null, () => {
                     if (opts.typesPrefix) {
@@ -801,12 +802,28 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                     } else if (node.fields) {
                         mockFieldsString = node.fields
                             .map((field) => {
+                                const typeName = field.type.kind === Kind.NAMED_TYPE ? field.type.name.value : null;
+                                const fieldIsOneOfType = Boolean(
+                                    typeName &&
+                                        astNode.definitions.find(
+                                            (definition) =>
+                                                definition.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION &&
+                                                definition.name.value === typeName &&
+                                                definition.directives.some(
+                                                    (directive) => directive.name.value === 'oneOf',
+                                                ),
+                                        ),
+                                );
+
                                 const value = generateMockValue({
                                     typeName: fieldName,
                                     fieldName: field.name.value,
                                     currentType: field.type,
                                     generatorMode: 'input',
                                     ...sharedGenerateMockOpts,
+                                    terminateCircularRelationships: fieldIsOneOfType
+                                        ? false
+                                        : sharedGenerateMockOpts.terminateCircularRelationships,
                                 });
 
                                 const valueWithOverride = `overrides && overrides.hasOwnProperty('${field.name.value}') ? overrides.${field.name.value}! : ${value}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { parse, TypeNode, ASTKindToNode, ListTypeNode, NamedTypeNode, ObjectTypeDefinitionNode, Kind } from 'graphql';
+import { parse, TypeNode, ASTKindToNode, ListTypeNode, NamedTypeNode, ObjectTypeDefinitionNode } from 'graphql';
 import * as allFakerLocales from '@faker-js/faker';
 import casual from 'casual';
 import { oldVisit, PluginFunction, resolveExternalModuleAndFn } from '@graphql-codegen/plugin-helpers';
@@ -34,6 +34,7 @@ type Options<T = TypeNode> = {
     defaultNullableToNull: boolean;
     nonNull: boolean;
     typeNamesMapping?: Record<string, string>;
+    inputOneOfTypes: Set<string>;
 };
 
 const getTerminateCircularRelationshipsConfig = ({ terminateCircularRelationships }: TypescriptMocksPluginConfig) =>
@@ -410,7 +411,7 @@ const getNamedType = (opts: Options<NamedTypeNode | ObjectTypeDefinitionNode>): 
                 }
             }
 
-            if (opts.terminateCircularRelationships) {
+            if (opts.terminateCircularRelationships && !opts.inputOneOfTypes.has(opts.currentType.name.value)) {
                 return handleValueGeneration(opts, null, () => {
                     if (opts.typesPrefix) {
                         const typeNameConverter = createNameConverter(
@@ -688,6 +689,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
 
     // List of types that are enums
     const types: TypeItem[] = [];
+    const inputOneOfTypes: Set<string> = new Set();
     const typeVisitor: VisitorType = {
         EnumTypeDefinition: (node) => {
             const name = node.name.value;
@@ -724,6 +726,11 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                 }
             }
         },
+        InputObjectTypeDefinition: (node) => {
+            if (node.directives.some((directive) => directive.name.value === 'oneOf')) {
+                inputOneOfTypes.add(node.name.value);
+            }
+        },
         ScalarTypeDefinition: (node) => {
             const name = node.name.value;
             if (!types.find((scalarType) => scalarType.name === name)) {
@@ -756,6 +763,7 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
         typesPrefix: config.typesPrefix,
         useImplementingTypes,
         useTypeImports,
+        inputOneOfTypes,
     };
 
     const visitor: VisitorType = {
@@ -802,28 +810,12 @@ export const plugin: PluginFunction<TypescriptMocksPluginConfig> = (schema, docu
                     } else if (node.fields) {
                         mockFieldsString = node.fields
                             .map((field) => {
-                                const typeName = field.type.kind === Kind.NAMED_TYPE ? field.type.name.value : null;
-                                const fieldIsOneOfType = Boolean(
-                                    typeName &&
-                                        astNode.definitions.find(
-                                            (definition) =>
-                                                definition.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION &&
-                                                definition.name.value === typeName &&
-                                                definition.directives.some(
-                                                    (directive) => directive.name.value === 'oneOf',
-                                                ),
-                                        ),
-                                );
-
                                 const value = generateMockValue({
                                     typeName: fieldName,
                                     fieldName: field.name.value,
                                     currentType: field.type,
                                     generatorMode: 'input',
                                     ...sharedGenerateMockOpts,
-                                    terminateCircularRelationships: fieldIsOneOfType
-                                        ? false
-                                        : sharedGenerateMockOpts.terminateCircularRelationships,
                                 });
 
                                 const valueWithOverride = `overrides && overrides.hasOwnProperty('${field.name.value}') ? overrides.${field.name.value}! : ${value}`;

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -70,6 +70,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : null,
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : null,
@@ -152,6 +158,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : null}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : null,
     };
 };
 
@@ -240,6 +252,12 @@ export const mockOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const mockContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : mockOneOfInput(),
+    };
+};
+
 export const mockMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : mockUser(),
@@ -325,6 +343,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -341,7 +365,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should add enumsPrefix to imports 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, Api } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, Api } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -408,6 +432,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -497,6 +527,12 @@ export const aOneOfInput = (override?: Api.OneOfInput): Api.OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<Api.ContainsOneOfInput>): Api.ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Api.Mutation>): Api.Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -579,6 +615,12 @@ export const anUpdateUserInput = (overrides?: Partial<Api.UpdateUserInput>): Api
 export const aOneOfInput = (override?: Api.OneOfInput): Api.OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<Api.ContainsOneOfInput>): Api.ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -668,6 +710,12 @@ export const aOneOfInput = (override?: Api.OneOfInput): Api.OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<Api.ContainsOneOfInput>): Api.ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Api.Mutation>): Api.Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -750,6 +798,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -838,6 +892,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -920,6 +980,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -1008,6 +1074,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -1090,6 +1162,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -1178,6 +1256,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : faker.lorem.word()}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -1271,6 +1355,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -1355,6 +1445,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -1443,6 +1539,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -1459,7 +1561,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should generate mock data functions with external types file import 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -1526,6 +1628,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -1614,6 +1722,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -1696,6 +1810,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -1810,6 +1930,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -1892,6 +2018,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -1980,6 +2112,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -1996,7 +2134,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should generate mock data with PascalCase types and enums by default 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -2063,6 +2201,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -2151,6 +2295,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -2233,6 +2383,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -2321,6 +2477,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -2406,6 +2568,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -2488,6 +2656,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -2583,6 +2757,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): { __typename: 'Mutation' } & Mutation => {
     return {
         __typename: 'Mutation',
@@ -2667,6 +2847,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -2755,6 +2941,12 @@ export const aONEOFINPUT = (override?: ONEOFINPUT): ONEOFINPUT => {
     };
 };
 
+export const aCONTAINSONEOFINPUT = (overrides?: Partial<CONTAINSONEOFINPUT>): CONTAINSONEOFINPUT => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aONEOFINPUT(),
+    };
+};
+
 export const aMUTATION = (overrides?: Partial<MUTATION>): MUTATION => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER(),
@@ -2771,7 +2963,7 @@ export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
 `;
 
 exports[`should generate mock data with upperCase types and imports if typeNames is "upper-case#upperCase" 1`] = `
-"import { AVATAR, USER, WITHAVATAR, CAMELCASETHING, PREFIXED_RESPONSE, ABCTYPE, LISTTYPE, UPDATEUSERINPUT, ONEOFINPUT, MUTATION, QUERY, ABCSTATUS, STATUS, PREFIXED_ENUM } from './types/graphql';
+"import { AVATAR, USER, WITHAVATAR, CAMELCASETHING, PREFIXED_RESPONSE, ABCTYPE, LISTTYPE, UPDATEUSERINPUT, ONEOFINPUT, CONTAINSONEOFINPUT, MUTATION, QUERY, ABCSTATUS, STATUS, PREFIXED_ENUM } from './types/graphql';
 
 export const anAVATAR = (overrides?: Partial<AVATAR>): AVATAR => {
     return {
@@ -2841,6 +3033,12 @@ export const aONEOFINPUT = (override?: ONEOFINPUT): ONEOFINPUT => {
     };
 };
 
+export const aCONTAINSONEOFINPUT = (overrides?: Partial<CONTAINSONEOFINPUT>): CONTAINSONEOFINPUT => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aONEOFINPUT(),
+    };
+};
+
 export const aMUTATION = (overrides?: Partial<MUTATION>): MUTATION => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUSER(),
@@ -2857,7 +3055,7 @@ export const aQUERY = (overrides?: Partial<QUERY>): QUERY => {
 `;
 
 exports[`should generate multiple list elements 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -2927,6 +3125,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -2943,7 +3147,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should generate no list elements when listElementCount is 0 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -3013,6 +3217,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -3029,7 +3239,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should generate single list element 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -3099,6 +3309,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -3115,7 +3331,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should not merge imports into one if enumsPrefix does not contain dots 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -3185,6 +3401,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -3201,7 +3423,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should not merge imports into one if typesPrefix does not contain dots 1`] = `
-"import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiListType, ApiUpdateUserInput, ApiOneOfInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';
+"import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiListType, ApiUpdateUserInput, ApiOneOfInput, ApiContainsOneOfInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<ApiAvatar>): ApiAvatar => {
     return {
@@ -3271,6 +3493,12 @@ export const aOneOfInput = (override?: ApiOneOfInput): ApiOneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ApiContainsOneOfInput>): ApiContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<ApiMutation>): ApiMutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -3287,7 +3515,7 @@ export const aQuery = (overrides?: Partial<ApiQuery>): ApiQuery => {
 `;
 
 exports[`should preserve underscores if transformUnderscore is false 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -3357,6 +3585,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -3373,7 +3607,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should preserve underscores if transformUnderscore is false and enumsAsTypes is true 1`] = `
-"import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query } from './types/graphql';
+"import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -3443,6 +3677,12 @@ export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     };
 };
 
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
 export const aMutation = (overrides?: Partial<Mutation>): Mutation => {
     return {
         updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : aUser(),
@@ -3459,7 +3699,7 @@ export const aQuery = (overrides?: Partial<Query>): Query => {
 `;
 
 exports[`should preserve underscores if transformUnderscore is false and enumsAsTypes is true as cast the enum type if useTypeImports is true 1`] = `
-"import type { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';
+"import type { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';
 
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
     return {
@@ -3526,6 +3766,12 @@ export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>): UpdateU
 export const aOneOfInput = (override?: OneOfInput): OneOfInput => {
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>): ContainsOneOfInput => {
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 
@@ -3629,6 +3875,14 @@ export const aOneOfInput = (override?: OneOfInput, _relationshipsToOmit: Set<str
     relationshipsToOmit.add('OneOfInput');
     return {
         ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>, _relationshipsToOmit: Set<string> = new Set()): ContainsOneOfInput => {
+    const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
+    relationshipsToOmit.add('ContainsOneOfInput');
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : relationshipsToOmit.has('OneOfInput') ? {} as OneOfInput : aOneOfInput({}, relationshipsToOmit),
     };
 };
 

--- a/tests/__snapshots__/typescript-mock-data.spec.ts.snap
+++ b/tests/__snapshots__/typescript-mock-data.spec.ts.snap
@@ -1378,6 +1378,121 @@ export const seedMocks = (seed: number) => casual.seed(seed);
 "
 `;
 
+exports[`should generate mock data for an input type containing a field with a oneOf directive 1`] = `
+"
+export const anAvatar = (overrides?: Partial<Avatar>, _relationshipsToOmit: Set<string> = new Set()): Avatar => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('Avatar');
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '15f9c394-c8fc-46bc-a882-b3b853f28c03',
+        url: overrides && overrides.hasOwnProperty('url') ? overrides.url! : 'consectetur',
+    };
+};
+
+export const aUser = (overrides?: Partial<User>, _relationshipsToOmit: Set<string> = new Set()): User => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('User');
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : 'b7605a2a-ad1e-4667-801e-5e47e5de933b',
+        creationDate: overrides && overrides.hasOwnProperty('creationDate') ? overrides.creationDate! : '2021-07-07T09:30:34.236Z',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'sordeo',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        status: overrides && overrides.hasOwnProperty('status') ? overrides.status! : Status.Online,
+        customStatus: overrides && overrides.hasOwnProperty('customStatus') ? overrides.customStatus! : AbcStatus.HasXyzStatus,
+        scalarValue: overrides && overrides.hasOwnProperty('scalarValue') ? overrides.scalarValue! : 'arx',
+        camelCaseThing: overrides && overrides.hasOwnProperty('camelCaseThing') ? overrides.camelCaseThing! : relationshipsToOmit.has('CamelCaseThing') ? {} as CamelCaseThing : aCamelCaseThing({}, relationshipsToOmit),
+        unionThing: overrides && overrides.hasOwnProperty('unionThing') ? overrides.unionThing! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+        prefixedEnum: overrides && overrides.hasOwnProperty('prefixedEnum') ? overrides.prefixedEnum! : PrefixedEnum.PrefixedValue,
+    };
+};
+
+export const aWithAvatar = (overrides?: Partial<WithAvatar>, _relationshipsToOmit: Set<string> = new Set()): WithAvatar => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('WithAvatar');
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '9f1e2e6d-2047-44ac-ac43-58f18eff5255',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+    };
+};
+
+export const aCamelCaseThing = (overrides?: Partial<CamelCaseThing>, _relationshipsToOmit: Set<string> = new Set()): CamelCaseThing => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('CamelCaseThing');
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '259f1f94-0fee-4e7d-8280-96dd5d8d9177',
+    };
+};
+
+export const aPrefixedResponse = (overrides?: Partial<PrefixedResponse>, _relationshipsToOmit: Set<string> = new Set()): PrefixedResponse => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('PrefixedResponse');
+    return {
+        ping: overrides && overrides.hasOwnProperty('ping') ? overrides.ping! : 'nam',
+    };
+};
+
+export const anAbcType = (overrides?: Partial<AbcType>, _relationshipsToOmit: Set<string> = new Set()): AbcType => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('AbcType');
+    return {
+        abc: overrides && overrides.hasOwnProperty('abc') ? overrides.abc! : 'accommodo',
+    };
+};
+
+export const aListType = (overrides?: Partial<ListType>, _relationshipsToOmit: Set<string> = new Set()): ListType => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('ListType');
+    return {
+        stringList: overrides && overrides.hasOwnProperty('stringList') ? overrides.stringList! : ['accusator'],
+        nullableStringList: overrides && overrides.hasOwnProperty('nullableStringList') ? overrides.nullableStringList! : ['tricesimus'],
+    };
+};
+
+export const anUpdateUserInput = (overrides?: Partial<UpdateUserInput>, _relationshipsToOmit: Set<string> = new Set()): UpdateUserInput => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('UpdateUserInput');
+    return {
+        id: overrides && overrides.hasOwnProperty('id') ? overrides.id! : '0696d260-ef45-407d-ac64-e375cbd7e441',
+        login: overrides && overrides.hasOwnProperty('login') ? overrides.login! : 'apud',
+        avatar: overrides && overrides.hasOwnProperty('avatar') ? overrides.avatar! : relationshipsToOmit.has('Avatar') ? {} as Avatar : anAvatar({}, relationshipsToOmit),
+    };
+};
+
+export const aOneOfInput = (override?: OneOfInput, _relationshipsToOmit: Set<string> = new Set()): OneOfInput => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('OneOfInput');
+    return {
+        ...(override ? override : {oneOfFieldA : 'tibi'}),
+    };
+};
+
+export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>, _relationshipsToOmit: Set<string> = new Set()): ContainsOneOfInput => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('ContainsOneOfInput');
+    return {
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
+    };
+};
+
+export const aMutation = (overrides?: Partial<Mutation>, _relationshipsToOmit: Set<string> = new Set()): Mutation => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('Mutation');
+    return {
+        updateUser: overrides && overrides.hasOwnProperty('updateUser') ? overrides.updateUser! : relationshipsToOmit.has('User') ? {} as User : aUser({}, relationshipsToOmit),
+    };
+};
+
+export const aQuery = (overrides?: Partial<Query>, _relationshipsToOmit: Set<string> = new Set()): Query => {
+    const relationshipsToOmit: Set<string> = _relationshipsToOmit;
+    relationshipsToOmit.add('Query');
+    return {
+        user: overrides && overrides.hasOwnProperty('user') ? overrides.user! : relationshipsToOmit.has('User') ? {} as User : aUser({}, relationshipsToOmit),
+        prefixed_query: overrides && overrides.hasOwnProperty('prefixed_query') ? overrides.prefixed_query! : relationshipsToOmit.has('PrefixedResponse') ? {} as PrefixedResponse : aPrefixedResponse({}, relationshipsToOmit),
+    };
+};
+"
+`;
+
 exports[`should generate mock data functions 1`] = `
 "
 export const anAvatar = (overrides?: Partial<Avatar>): Avatar => {
@@ -3882,7 +3997,7 @@ export const aContainsOneOfInput = (overrides?: Partial<ContainsOneOfInput>, _re
     const relationshipsToOmit: Set<string> = new Set(_relationshipsToOmit);
     relationshipsToOmit.add('ContainsOneOfInput');
     return {
-        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : relationshipsToOmit.has('OneOfInput') ? {} as OneOfInput : aOneOfInput({}, relationshipsToOmit),
+        field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),
     };
 };
 

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -135,6 +135,16 @@ it('should generate mock data for an input type with a oneOf directive', async (
     expect(result).toContain(`...(override ? override : {oneOfFieldA : 'tibi'}),`);
 });
 
+it('should generate mock data for an input type containing a field with a oneOf directive', async () => {
+    const result = await plugin(testSchema, [], {
+        terminateCircularRelationships: 'immediate',
+    });
+
+    expect(result).toBeDefined();
+
+    expect(result).toMatchSnapshot();
+});
+
 it('should generate mock data functions with external types file import', async () => {
     const result = await plugin(testSchema, [], { typesFile: './types/graphql.ts' });
 

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -60,6 +60,10 @@ const testSchema = buildSchema(/* GraphQL */ `
         oneOfFieldB: String
     }
 
+    input ContainsOneOfInput {
+        field: OneOfInput
+    }
+
     enum ABCStatus {
         hasXYZStatus
     }
@@ -136,7 +140,7 @@ it('should generate mock data functions with external types file import', async 
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';",
+        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, PrefixedEnum } from './types/graphql';",
     );
     expect(result).toMatchSnapshot();
 });
@@ -394,7 +398,7 @@ it('should add enumsPrefix to imports', async () => {
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, Api } from './types/graphql';",
+        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, Api } from './types/graphql';",
     );
     expect(result).toMatchSnapshot();
 });
@@ -419,7 +423,7 @@ it('should not merge imports into one if typesPrefix does not contain dots', asy
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiListType, ApiUpdateUserInput, ApiOneOfInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';",
+        "import { ApiAvatar, ApiUser, ApiWithAvatar, ApiCamelCaseThing, ApiPrefixedResponse, ApiAbcType, ApiListType, ApiUpdateUserInput, ApiOneOfInput, ApiContainsOneOfInput, ApiMutation, ApiQuery, AbcStatus, Status, PrefixedEnum } from './types/graphql';",
     );
     expect(result).toMatchSnapshot();
 });
@@ -432,7 +436,7 @@ it('should not merge imports into one if enumsPrefix does not contain dots', asy
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';",
+        "import { Avatar, User, WithAvatar, CamelCaseThing, PrefixedResponse, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, ApiAbcStatus, ApiStatus, ApiPrefixedEnum } from './types/graphql';",
     );
     expect(result).toMatchSnapshot();
 });
@@ -456,7 +460,7 @@ it('should preserve underscores if transformUnderscore is false', async () => {
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';",
+        "import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';",
     );
     expect(result).toContain(
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
@@ -476,7 +480,7 @@ it('should preserve underscores if transformUnderscore is false and enumsAsTypes
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query } from './types/graphql';",
+        "import { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query } from './types/graphql';",
     );
     expect(result).toContain(
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',
@@ -497,7 +501,7 @@ it('should preserve underscores if transformUnderscore is false and enumsAsTypes
 
     expect(result).toBeDefined();
     expect(result).toContain(
-        "import type { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';",
+        "import type { Avatar, User, WithAvatar, CamelCaseThing, Prefixed_Response, AbcType, ListType, UpdateUserInput, OneOfInput, ContainsOneOfInput, Mutation, Query, AbcStatus, Status, Prefixed_Enum } from './types/graphql';",
     );
     expect(result).toContain(
         'export const aPrefixed_Response = (overrides?: Partial<Prefixed_Response>): Prefixed_Response => {',

--- a/tests/typescript-mock-data.spec.ts
+++ b/tests/typescript-mock-data.spec.ts
@@ -141,7 +141,9 @@ it('should generate mock data for an input type containing a field with a oneOf 
     });
 
     expect(result).toBeDefined();
-
+    expect(result).toContain(
+        `field: overrides && overrides.hasOwnProperty('field') ? overrides.field! : aOneOfInput(),`,
+    );
     expect(result).toMatchSnapshot();
 });
 


### PR DESCRIPTION
Fixes https://github.com/ardeois/graphql-codegen-typescript-mock-data/issues/193

Skip `terminateCircularRelationships` logic for fields who's types are input objects with the `@oneOf` directive. This fixes the generation of incorrect code with type errors.