### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "module": "dist/esnext/index.js",
     "typings": "dist/esnext/index.d.ts",
     "repository": "ardeois/graphql-codegen-typescript-mock-data",
+    "bugs": {
+        "url": "https://github.com/ardeois/graphql-codegen-typescript-mock-data/issues"
+    },
+    "homepage": "https://github.com/ardeois/graphql-codegen-typescript-mock-data#readme",
     "author": {
         "name": "Corentin Ardeois",
         "email": "corentin.ardeois@gmail.com",


### PR DESCRIPTION
## Summary
Add npm package support metadata:
- `bugs.url` points to the repository issue tracker
- `homepage` points to the package README

This is a package manifest-only change. It does not change runtime code, generated output, dependencies, or package versioning.

## Verification
- Parsed `package.json` and confirmed `name`, `license`, `repository`, `homepage`, and `bugs.url`
- `npm pack --dry-run --json` with a temporary no-op `husky` on PATH because the local checkout has no installed dependencies and the package `prepare` script runs `husky install`
- `git diff --check`