### PR TITLE
docs: add missing homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,96 +1,96 @@
 {
-    "name": "graphql-codegen-typescript-mock-data",
-    "version": "5.1.1",
-    "description": "GraphQL Codegen plugin for building mock data",
-    "main": "dist/commonjs/index.js",
-    "module": "dist/esnext/index.js",
-    "typings": "dist/esnext/index.d.ts",
-    "repository": "ardeois/graphql-codegen-typescript-mock-data",
-    "bugs": {
-        "url": "https://github.com/ardeois/graphql-codegen-typescript-mock-data/issues"
-    },
-    "homepage": "https://github.com/ardeois/graphql-codegen-typescript-mock-data#readme",
-    "author": {
-        "name": "Corentin Ardeois",
-        "email": "corentin.ardeois@gmail.com",
-        "url": "https://github.com/ardeois"
-    },
-    "license": "MIT",
-    "keywords": [
-        "graphql",
-        "codegen",
-        "graphql-codegen",
-        "plugin",
-        "typescript",
-        "mocks",
-        "fakes"
+  "name": "graphql-codegen-typescript-mock-data",
+  "version": "5.1.1",
+  "description": "GraphQL Codegen plugin for building mock data",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esnext/index.js",
+  "typings": "dist/esnext/index.d.ts",
+  "repository": "ardeois/graphql-codegen-typescript-mock-data",
+  "bugs": {
+    "url": "https://github.com/ardeois/graphql-codegen-typescript-mock-data/issues"
+  },
+  "homepage": "https://github.com/ardeois/graphql-codegen-typescript-mock-data#readme",
+  "author": {
+    "name": "Corentin Ardeois",
+    "email": "corentin.ardeois@gmail.com",
+    "url": "https://github.com/ardeois"
+  },
+  "license": "MIT",
+  "keywords": [
+    "graphql",
+    "codegen",
+    "graphql-codegen",
+    "plugin",
+    "typescript",
+    "mocks",
+    "fakes"
+  ],
+  "dependencies": {
+    "@faker-js/faker": "^9.8.0",
+    "@graphql-codegen/plugin-helpers": "^5.0.4",
+    "@graphql-tools/utils": "^10.7.2",
+    "casual": "^1.6.2",
+    "change-case-all": "^1.0.15",
+    "indefinite": "^2.4.1",
+    "pascal-case": "^3.1.1",
+    "sentence-case": "^3.0.3",
+    "tslib": "^2.4.0",
+    "upper-case": "^2.0.1"
+  },
+  "peerDependencies": {
+    "graphql": "^14.6.0 || ^15.0.0 || ^16.0.0",
+    "typescript": ">=5.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@auto-it/conventional-commits": "^11.1.6",
+    "@graphql-codegen/testing": "^3.0.3",
+    "@graphql-codegen/typescript": "^4.0.7",
+    "@types/indefinite": "^2.3.4",
+    "@types/jest": "^27.0.2",
+    "@typescript-eslint/eslint-plugin": "^5.1.0",
+    "@typescript-eslint/parser": "^5.1.0",
+    "auto": "^11.1.6",
+    "eslint": "8.0.1",
+    "eslint-config-landr": "0.7.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-jest": "^25.2.2",
+    "eslint-plugin-prettier": "^4.0.0",
+    "graphql": "^16.3.0",
+    "husky": "^7.0.0",
+    "jest": "^27.3.1",
+    "jest-diff": "^27.5.1",
+    "lint-staged": "^11.2.3",
+    "prettier": "^2.4.1",
+    "prettier-config-landr": "^0.2.0",
+    "ts-jest": "^27.0.7",
+    "typescript": "^5.7.3"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc -m esnext --outDir dist/esnext && tsc -m commonjs --outDir dist/commonjs",
+    "test": "TZ=UTC LANG=en_US.UTF8 jest",
+    "lint": "eslint 'src/**/*.{js,ts,tsx}' --quiet --fix && tsc --noEmit",
+    "prettify": "prettier --config ./.prettierrc.js --write",
+    "auto:version": "yarn version --`auto version` --message 'Bump version to: %s [skip ci]'",
+    "auto:publish": "yarn publish && git push --follow-tags --set-upstream origin $CIRCLE_BRANCH",
+    "release": "auto changelog && yarn auto:version && yarn auto:publish && auto release",
+    "prepare": "husky install"
+  },
+  "lint-staged": {
+    "*.{js,ts,tsx}": [
+      "eslint --quiet --fix"
     ],
-    "dependencies": {
-        "@faker-js/faker": "^9.8.0",
-        "@graphql-codegen/plugin-helpers": "^5.0.4",
-        "@graphql-tools/utils": "^10.7.2",
-        "casual": "^1.6.2",
-        "change-case-all": "^1.0.15",
-        "indefinite": "^2.4.1",
-        "pascal-case": "^3.1.1",
-        "sentence-case": "^3.0.3",
-        "tslib": "^2.4.0",
-        "upper-case": "^2.0.1"
-    },
-    "peerDependencies": {
-        "graphql": "^14.6.0 || ^15.0.0 || ^16.0.0",
-        "typescript": ">=5.0.0"
-    },
-    "engines": {
-        "node": ">=18.0.0"
-    },
-    "devDependencies": {
-        "@auto-it/conventional-commits": "^11.1.6",
-        "@graphql-codegen/testing": "^3.0.3",
-        "@graphql-codegen/typescript": "^4.0.7",
-        "@types/indefinite": "^2.3.4",
-        "@types/jest": "^27.0.2",
-        "@typescript-eslint/eslint-plugin": "^5.1.0",
-        "@typescript-eslint/parser": "^5.1.0",
-        "auto": "^11.1.6",
-        "eslint": "8.0.1",
-        "eslint-config-landr": "0.7.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-jest": "^25.2.2",
-        "eslint-plugin-prettier": "^4.0.0",
-        "graphql": "^16.3.0",
-        "husky": "^7.0.0",
-        "jest": "^27.3.1",
-        "jest-diff": "^27.5.1",
-        "lint-staged": "^11.2.3",
-        "prettier": "^2.4.1",
-        "prettier-config-landr": "^0.2.0",
-        "ts-jest": "^27.0.7",
-        "typescript": "^5.7.3"
-    },
-    "sideEffects": false,
-    "scripts": {
-        "build": "tsc -m esnext --outDir dist/esnext && tsc -m commonjs --outDir dist/commonjs",
-        "test": "TZ=UTC LANG=en_US.UTF8 jest",
-        "lint": "eslint 'src/**/*.{js,ts,tsx}' --quiet --fix && tsc --noEmit",
-        "prettify": "prettier --config ./.prettierrc.js --write",
-        "auto:version": "yarn version --`auto version` --message 'Bump version to: %s [skip ci]'",
-        "auto:publish": "yarn publish && git push --follow-tags --set-upstream origin $CIRCLE_BRANCH",
-        "release": "auto changelog && yarn auto:version && yarn auto:publish && auto release",
-        "prepare": "husky install"
-    },
-    "lint-staged": {
-        "*.{js,ts,tsx}": [
-            "eslint --quiet --fix"
-        ],
-        "*.{json,md,html}": [
-            "prettier --write"
-        ]
-    },
-    "files": [
-        "dist/**/*",
-        "LICENSE",
-        "README.md"
+    "*.{json,md,html}": [
+      "prettier --write"
     ]
+  },
+  "files": [
+    "dist/**/*",
+    "LICENSE",
+    "README.md"
+  ]
 }


### PR DESCRIPTION
This PR fixes the following issue reported in charles-microbounties:
- Issue #1210: graphql-codegen-typescript-mock-data lacks homepage and bugs metadata

Changes:
- Added 'homepage': 'https://github.com/ardeois/graphql-codegen-typescript-mock-data#readme'
- Added 'bugs': { 'url': 'https://github.com/ardeois/graphql-codegen-typescript-mock-data/issues' }

Verified with publint.