### PR TITLE
build(deps): bump @graphql-codegen/plugin-helpers from ^5.0.4 to ^6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ],
     "dependencies": {
         "@faker-js/faker": "^9.8.0",
-        "@graphql-codegen/plugin-helpers": "^5.0.4",
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
         "@graphql-tools/utils": "^10.7.2",
         "casual": "^1.6.2",
         "change-case-all": "^1.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^9.8.0
         version: 9.9.0
       '@graphql-codegen/plugin-helpers':
-        specifier: ^5.0.4
-        version: 5.1.1(graphql@16.14.2)
+        specifier: ^6.3.0
+        version: 6.3.0(graphql@16.14.2)
       '@graphql-tools/utils':
         specifier: ^10.7.2
         version: 10.11.0(graphql@16.14.2)
@@ -353,6 +353,12 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
+  '@graphql-codegen/plugin-helpers@6.3.0':
+    resolution: {integrity: sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
   '@graphql-codegen/schema-ast@4.1.0':
     resolution: {integrity: sha512-kZVn0z+th9SvqxfKYgztA6PM7mhnSZaj4fiuBWvMTqA+QqQ9BBed6Pz41KuD/jr0gJtnlr2A4++/0VlpVbCTmQ==}
     peerDependencies:
@@ -395,8 +401,8 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@graphql-tools/utils@11.1.0':
-    resolution: {integrity: sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==}
+  '@graphql-tools/utils@11.2.2':
+    resolution: {integrity: sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -1116,6 +1122,7 @@ packages:
   conventional-changelog-core@4.2.4:
     resolution: {integrity: sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==}
     engines: {node: '>=10'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@2.3.4:
     resolution: {integrity: sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==}
@@ -1674,7 +1681,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -1684,7 +1691,7 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -3929,6 +3936,15 @@ snapshots:
       lodash: 4.18.1
       tslib: 2.6.3
 
+  '@graphql-codegen/plugin-helpers@6.3.0(graphql@16.14.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.2.2(graphql@16.14.2)
+      change-case-all: 1.0.15
+      common-tags: 1.8.2
+      graphql: 16.14.2
+      import-from: 4.0.0
+      tslib: 2.8.1
+
   '@graphql-codegen/schema-ast@4.1.0(graphql@16.14.2)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.14.2)
@@ -3981,7 +3997,7 @@ snapshots:
   '@graphql-tools/relay-operation-optimizer@7.1.4(graphql@16.14.2)':
     dependencies:
       '@ardatan/relay-compiler': 13.0.1(graphql@16.14.2)
-      '@graphql-tools/utils': 11.1.0(graphql@16.14.2)
+      '@graphql-tools/utils': 11.2.2(graphql@16.14.2)
       graphql: 16.14.2
       tslib: 2.8.1
 
@@ -3993,7 +4009,7 @@ snapshots:
       graphql: 16.14.2
       tslib: 2.8.1
 
-  '@graphql-tools/utils@11.1.0(graphql@16.14.2)':
+  '@graphql-tools/utils@11.2.2(graphql@16.14.2)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
       '@whatwg-node/promise-helpers': 1.3.2
@@ -4171,7 +4187,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.3
+      '@types/node': 24.13.2
       '@types/yargs': 16.0.11
       chalk: 4.1.2
 
@@ -4346,7 +4362,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.2
 
   '@types/indefinite@2.3.4': {}
 
@@ -6220,7 +6236,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.9.3
+      '@types/node': 24.13.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6369,7 +6385,7 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.2
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
@@ -6429,7 +6445,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
## What

Bumps `@graphql-codegen/plugin-helpers` from `^5.0.4` to `^6.3.0`.

Fixes #213

## Why

`plugin-helpers` 5.x depends on `lodash: ~4.17.0`, which resolves to versions affected by GHSA-r5fr-rjxr-66jc (high, `_.template` code injection) and GHSA-f23m-r3pf-42rh (moderate, prototype pollution). The tilde range can never reach a patched build — the fix only ships in lodash 4.18.x (public 4.17.23 exists but is not patched).

This repo already mitigates it locally via the `lodash: '>=4.18.0'` override in `pnpm-workspace.yaml`, but pnpm overrides don't propagate to consumers — anyone installing this package still inherits the vulnerable range. Bumping the declared dependency closes that gap.

## Why `^6.3.0` and not `^6.0.0` or 7.x

- #213 suggests `^6.0.0`, but plugin-helpers 6.0.0–6.2.0 still declare `lodash ~4.17.0` — lodash was dropped in **6.3.0**, the final 6.x release.
- 7.x switches to the ESM-only `change-case-all@^2.1.0`, which this repo's jest 27 toolchain cannot load — with 7.1.0, 11 of 14 test suites fail (`Jest encountered an unexpected token` via `resolve-external-module-and-fn.js`). `^6.3.0` stays on the CJS-compatible line while allowing any future 6.x patch.
- API compatibility: this codebase imports exactly two symbols from plugin-helpers — `oldVisit` and `resolveExternalModuleAndFn` — both unchanged in 6.3.0.

## Validation (node 24, pnpm 11.7.0, fresh install)

- `pnpm install --frozen-lockfile`: passes (lockfile in sync with the manifest)
- `pnpm test`: 14/14 suites, 125/125 tests, 116 snapshots pass
- `pnpm build`: clean
- `pnpm why lodash --prod`: empty — no lodash left in the published dependency chain

The remaining `plugin-helpers@5.1.1` in the lockfile comes only from devDependencies (`@graphql-codegen/typescript`, `@graphql-codegen/testing`) and does not reach consumers; it stays covered by the existing workspace override.